### PR TITLE
Windows Path Error in OAuth Keys Loading

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { google } from 'googleapis';
 import { OAuth2Client } from 'google-auth-library';
 import * as fs from 'fs/promises';
 import * as path from 'path';
+import { fileURLToPath } from 'url';
 import { z } from "zod";
 import { AuthServer } from './auth-server.js';
 import { TokenManager } from './token-manager.js';
@@ -103,10 +104,8 @@ let authServer: AuthServer;
 
 // Helper function to get secure token path
 function getSecureTokenPath(): string {
-  return path.join(
-    path.dirname(new URL(import.meta.url).pathname),
-    '../.gcp-saved-tokens.json'
-  );
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  return path.join(__dirname, '../.gcp-saved-tokens.json');
 }
 
 // Helper function to load and refresh tokens
@@ -450,10 +449,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 });
 
 function getKeysFilePath(): string {
-  const relativePath = path.join(
-    path.dirname(new URL(import.meta.url).pathname),
-    '../gcp-oauth.keys.json'
-  );
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const relativePath = path.join(__dirname, '../gcp-oauth.keys.json');
   const absolutePath = path.resolve(relativePath);
   return absolutePath;
 }

--- a/src/token-manager.ts
+++ b/src/token-manager.ts
@@ -1,6 +1,7 @@
 import { OAuth2Client, Credentials } from 'google-auth-library';
 import * as fs from 'fs/promises';
 import * as path from 'path';
+import { fileURLToPath } from 'url';
 
 export class TokenManager {
   private oauth2Client: OAuth2Client;
@@ -16,10 +17,8 @@ export class TokenManager {
   }
 
   private getSecureTokenPath(): string {
-    return path.join(
-      path.dirname(new URL(import.meta.url).pathname),
-      '../.gcp-saved-tokens.json'
-    );
+    const __dirname = path.dirname(fileURLToPath(import.meta.url));
+    return path.join(__dirname, '../.gcp-saved-tokens.json');
   }
 
   private calculateJitter(retryCount: number): number {


### PR DESCRIPTION
# Bug Report: Windows Path Error in OAuth Keys Loading

## Description
When running the application on a Windows system, it fails to start due to an incorrect file path when loading the OAuth keys.

## Error Message
```
# npm start
> google-calendar-mcp@1.0.1 start
> node build/index.js
Error loading OAuth keys: Error: ENOENT: no such file or directory, open 'D:\D:\Projects\google-calendar-mcp\gcp-oauth.keys.json'
    at async open (node:internal/fs/promises:638:25)
    at async Module.readFile (node:internal/fs/promises:1242:14)
    at async initializeOAuth2Client (file:///D:/Projects/google-calendar-mcp/build/index.js:321:25)
    at async main (file:///D:/Projects/google-calendar-mcp/build/index.js:610:20) {
  code: 'ENOENT',
  syscall: 'open',
  path: 'D:\\D:\\Projects\\google-calendar-mcp\\gcp-oauth.keys.json'
}
```

## Issue Details
* The path to the OAuth keys file is incorrectly formed with a duplicate drive reference: `D:\D:\Projects\...`
* This appears to be a Windows-specific issue with path handling
* The error occurs in the `initializeOAuth2Client` function at line 321 in `index.js`

## Possible Cause
The code is likely using path concatenation without properly handling Windows drive letters. When forming the file path, it's prepending the drive letter twice, resulting in an invalid path that cannot be found.

## Environment
* OS: Windows
* Package version: google-calendar-mcp@1.0.1
* Node.js version: [Unknown, using node:internal modules]

## Additional Notes
The application is trying to access `gcp-oauth.keys.json` at the project root, but the path resolution is failing specifically on Windows systems.