### PR TITLE
Fix build script to include auth-server.ts

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -22,12 +22,28 @@ const buildOptions = {
   sourcemap: true,
 };
 
+/** @type {import('esbuild').BuildOptions} */
+const authServerBuildOptions = {
+  entryPoints: [join(__dirname, '../src/auth-server.ts')],
+  bundle: true,
+  platform: 'node',
+  target: 'node18',
+  outfile: join(__dirname, '../build/auth-server.js'),
+  format: 'esm',
+  packages: 'external', // Don't bundle node_modules
+  sourcemap: true,
+};
+
 if (isWatch) {
   const context = await esbuild.context(buildOptions);
-  await context.watch();
+  const authContext = await esbuild.context(authServerBuildOptions);
+  await Promise.all([context.watch(), authContext.watch()]);
   console.log('Watching for changes...');
 } else {
-  await esbuild.build(buildOptions);
+  await Promise.all([
+    esbuild.build(buildOptions),
+    esbuild.build(authServerBuildOptions)
+  ]);
   
   // Make the file executable on non-Windows platforms
   if (process.platform !== 'win32') {


### PR DESCRIPTION
## Summary
- Modified the build script to build both index.ts and auth-server.ts files
- Previously only index.ts was being built, which caused the auth command to fail with 'MODULE_NOT_FOUND' error
- Updated both the watch and build modes to handle multiple entry points

## Test plan
1. Run `npm run build` to verify both files are built
2. Run `npm run auth` to verify the auth server now works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)