### PR TITLE
Feature - Add color-coding support

### DIFF
--- a/.cursorignore
+++ b/.cursorignore
@@ -1,0 +1,2 @@
+.gcp-saved-tokens.json
+gcp-oauth.keys.json

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This is a Model Context Protocol (MCP) server that provides integration with Goo
 - Update existing events
 - Delete events
 - Process events from screenshots and images
+- Color-code different events for better visual organization
 
 ## Requirements
 
@@ -57,6 +58,7 @@ google-calendar-mcp/
    npm run build
    ```
 4. Download your Google OAuth credentials from the Google Cloud Console (under "Credentials") and rename the file to `gcp-oauth.keys.json` and place it in the root directory of the project.
+   - Alternatively, copy the provided template file: `cp gcp-oauth.keys.example.json gcp-oauth.keys.json` and populate it with your credentials from the Google Cloud Console.
 
 ## Available Scripts
 
@@ -99,7 +101,7 @@ This will:
 3. Save the tokens and exit
 
 ### Security Notes
-- OAuth credentials are stored in `gcp-oauth.keys.json`
+- OAuth credentials are stored in `gcp-oauth.keys.json` (you can use the included `gcp-oauth.keys.example.json` template as a starting point)
 - Authentication tokens are stored in `.gcp-saved-tokens.json` with 600 permissions
 - Tokens are automatically refreshed in the background
 - Token integrity is validated before each API call
@@ -114,6 +116,7 @@ The server exposes the following tools:
    - `create-event`: Create a new calendar event
    - `update-event`: Update an existing calendar event
    - `delete-event`: Delete a calendar event
+   - `list-colors`: List available colors for events and calendars
 
 ## Using with Claude Desktop
 
@@ -165,7 +168,7 @@ Common issues and solutions:
    - Apps that are in testing mode, rather than production, will need to go through the OAuth flow again after a week.
 
 3. OAuth Token Errors
-   - Ensure your `gcp-oauth.keys.json` is correctly formatted
+   - Ensure your `gcp-oauth.keys.json` is correctly formatted (check against the structure in `gcp-oauth.keys.example.json`)
    - Try deleting `.gcp-saved-tokens.json` and re-authenticating
    
 4. TypeScript Build Errors

--- a/gcp-oauth.keys.example.json
+++ b/gcp-oauth.keys.example.json
@@ -1,0 +1,7 @@
+{
+    "installed": {
+        "client_id": "YOUR_GOOGLE_CLIENT_ID",
+        "client_secret": "YOUR_GOOGLE_CLIENT_SECRET",
+        "redirect_uris": ["http://localhost:3000"]
+    }
+}


### PR DESCRIPTION
# Description

**What**
- Add support for assigning colors to calendar events through the MCP server 🎨 
- Add `gcp-oauth.keys.example.json` file
- Add `.cursorignore` file

**Why**

-  Color-coding calendar events is a nice tool for visually organizing the day - turned out adding `colorId` support to this MCP was very simple - @nspady nice work on this tool, thanks for all your hard work! 

- Added `gcp-oauth.keys.example.json` as a reference for initial project setup + debugging.

- Added `.cursorignore` file to ensure that [Cursor](https://www.cursor.com/) doesn't consume sensitive OAuth credentials.

**How**

- Add `list-colors` tool to MCP server to fetch the list of colors and their respective internal IDs
- Add optional `colorId` parameter for creating + updating calendar events.

## Type of change

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [X] New feature (non-breaking change which adds functionality)
-   [ ] Chore (non-breaking enhancement/refinement)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

## Screenshots

![Screenshot 2025-03-22 at 7 02 08 AM](https://github.com/user-attachments/assets/2c341465-3966-45da-a4da-a6808192acf6)
