### PR TITLE
Add support for email + push notification reminders

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This is a Model Context Protocol (MCP) server that provides integration with Goo
   - Update existing events
   - Delete events
   - Manage event attendees and responses
+  - Set and manage event reminders (email and popup notifications)
   - Support for multiple calendars (both primary and secondary)
 
 - Security & Authentication:

--- a/src/index.ts
+++ b/src/index.ts
@@ -192,6 +192,39 @@ async function loadSavedTokens(): Promise<boolean> {
   }
 }
 
+
+const reminders_input_property = {
+    type: "object",
+    description: "Reminder settings for the event",
+    properties: {
+      useDefault: {
+        type: "boolean",
+        description: "Whether to use the default reminders",
+      },
+      overrides: {
+        type: "array",
+        description: "Custom reminders (uses popup notifications by default unless email is specified)",
+        items: {
+          type: "object",
+          properties: {
+            method: {
+              type: "string",
+              enum: ["email", "popup"],
+              description: "Reminder method (defaults to popup unless email is specified)",
+              default: "popup"
+            },
+            minutes: {
+              type: "number",
+              description: "Minutes before the event to trigger the reminder",
+            }
+          },
+          required: ["minutes"]
+        }
+      }
+    },
+    required: ["useDefault"]
+}
+
 // List available tools
 server.setRequestHandler(ListToolsRequestSchema, async () => {
   return {
@@ -284,37 +317,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
               type: "string",
               description: "Color ID for the event",
             },
-            reminders: {
-              type: "object",
-              description: "Reminder settings for the event",
-              properties: {
-                useDefault: {
-                  type: "boolean",
-                  description: "Whether to use the default reminders",
-                },
-                overrides: {
-                  type: "array",
-                  description: "Custom reminders (uses popup notifications by default unless email is specified)",
-                  items: {
-                    type: "object",
-                    properties: {
-                      method: {
-                        type: "string",
-                        enum: ["email", "popup"],
-                        description: "Reminder method (defaults to popup unless email is specified)",
-                        default: "popup"
-                      },
-                      minutes: {
-                        type: "number",
-                        description: "Minutes before the event to trigger the reminder",
-                      }
-                    },
-                    required: ["minutes"]
-                  }
-                }
-              },
-              required: ["useDefault"]
-            }
+            reminders: reminders_input_property
           },
           required: ["calendarId", "summary", "start", "end"],
         },
@@ -372,35 +375,8 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
               }
             },
             reminders: {
-              type: "object",
+              ...reminders_input_property,
               description: "New reminder settings for the event",
-              properties: {
-                useDefault: {
-                  type: "boolean",
-                  description: "Whether to use the default reminders",
-                },
-                overrides: {
-                  type: "array",
-                  description: "Custom reminders (uses popup notifications by default unless email is specified)",
-                  items: {
-                    type: "object",
-                    properties: {
-                      method: {
-                        type: "string",
-                        enum: ["email", "popup"],
-                        description: "Reminder method (defaults to popup unless email is specified)",
-                        default: "popup"
-                      },
-                      minutes: {
-                        type: "number",
-                        description: "Minutes before the event to trigger the reminder",
-                      }
-                    },
-                    required: ["minutes"]
-                  }
-                }
-              },
-              required: ["useDefault"]
             }
           },
           required: ["calendarId", "eventId"],


### PR DESCRIPTION
# Description

**What**

- Add support for Reminder (email + popup) notifications when creating + editing calendar events:

- For example, `Add grocery shopping to my calendar tomorrow afternoon, and send me a notification 15 minutes before and at the start of the event`

**Why**

- I've been manually setting reminders on all my MCP-managed calendar events and finally got impatient enough to open another PR

**How**

-   Updated `CalendarEvent` interfaces + Zod schemas to include support for Reminders.
- Set default reminder type to `popup` (push notification) - `email` notifications must be explicitly requested.

## Type of change

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [X] New feature (non-breaking change which adds functionality)
-   [ ] Chore (non-breaking enhancement/refinement)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

## Screenshots

![Screenshot 2025-03-26 at 5 00 17 PM](https://github.com/user-attachments/assets/5604e1b0-093c-4a7e-8811-7204dc05f417)
