### PR TITLE
Match the Google Calendar API's requirements for datetimes

### DIFF
--- a/src/handlers/listTools.ts
+++ b/src/handlers/listTools.ts
@@ -57,13 +57,13 @@ export function getToolDefinitions() {
             },
             timeMin: {
               type: "string",
-              format: "date-time", // Indicate ISO 8601 format expected
-              description: "Start time in ISO format (optional, e.g., 2024-01-01T00:00:00Z)",
+              format: "date-time",
+              description: "Start time in ISO format with timezone required (e.g., 2024-01-01T00:00:00Z or 2024-01-01T00:00:00+00:00). Date-time must end with Z (UTC) or +/-HH:MM offset.",
             },
             timeMax: {
               type: "string",
-              format: "date-time", // Indicate ISO 8601 format expected
-              description: "End time in ISO format (optional, e.g., 2024-12-31T23:59:59Z)",
+              format: "date-time",
+              description: "End time in ISO format with timezone required (e.g., 2024-12-31T23:59:59Z or 2024-12-31T23:59:59+00:00). Date-time must end with Z (UTC) or +/-HH:MM offset.",
             },
           },
           required: ["calendarId"],
@@ -86,12 +86,12 @@ export function getToolDefinitions() {
             timeMin: {
               type: "string",
               format: "date-time",
-              description: "Start time boundary in ISO format (optional)",
+              description: "Start time boundary in ISO format with timezone required (e.g., 2024-01-01T00:00:00Z or 2024-01-01T00:00:00+00:00). Date-time must end with Z (UTC) or +/-HH:MM offset.",
             },
             timeMax: {
               type: "string",
               format: "date-time",
-              description: "End time boundary in ISO format (optional)",
+              description: "End time boundary in ISO format with timezone required (e.g., 2024-12-31T23:59:59Z or 2024-12-31T23:59:59+00:00). Date-time must end with Z (UTC) or +/-HH:MM offset.",
             },
           },
           required: ["calendarId", "query"],
@@ -127,12 +127,12 @@ export function getToolDefinitions() {
             start: {
               type: "string",
               format: "date-time",
-              description: "Start time in ISO format (e.g., 2024-08-15T10:00:00-07:00)",
+              description: "Start time in ISO format with timezone required (e.g., 2024-08-15T10:00:00Z or 2024-08-15T10:00:00-07:00). Date-time must end with Z (UTC) or +/-HH:MM offset.",
             },
             end: {
               type: "string",
               format: "date-time",
-              description: "End time in ISO format (e.g., 2024-08-15T11:00:00-07:00)",
+              description: "End time in ISO format with timezone required (e.g., 2024-08-15T11:00:00Z or 2024-08-15T11:00:00-07:00). Date-time must end with Z (UTC) or +/-HH:MM offset.",
             },
             timeZone: {
               type: "string",
@@ -200,12 +200,12 @@ export function getToolDefinitions() {
             start: {
               type: "string",
               format: "date-time",
-              description: "New start time in ISO format (optional)",
+              description: "New start time in ISO format with timezone required (e.g., 2024-08-15T10:00:00Z or 2024-08-15T10:00:00-07:00). Date-time must end with Z (UTC) or +/-HH:MM offset.",
             },
             end: {
               type: "string",
               format: "date-time",
-              description: "New end time in ISO format (optional)",
+              description: "New end time in ISO format with timezone required (e.g., 2024-08-15T11:00:00Z or 2024-08-15T11:00:00-07:00). Date-time must end with Z (UTC) or +/-HH:MM offset.",
             },
             timeZone: {
               type: "string",

--- a/src/schemas/validators.ts
+++ b/src/schemas/validators.ts
@@ -12,25 +12,36 @@ export const RemindersSchema = z.object({
   overrides: z.array(ReminderSchema).optional(),
 });
 
+// ISO datetime regex that requires timezone designator (Z or +/-HH:MM)
+const isoDateTimeWithTimezone = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(Z|[+-]\d{2}:\d{2})$/;
+
 export const ListEventsArgumentsSchema = z.object({
   calendarId: z.string(),
-  timeMin: z.string().optional(),
-  timeMax: z.string().optional(),
+  timeMin: z.string()
+    .regex(isoDateTimeWithTimezone, "Must be ISO format with timezone (e.g., 2024-01-01T00:00:00Z)")
+    .optional(),
+  timeMax: z.string()
+    .regex(isoDateTimeWithTimezone, "Must be ISO format with timezone (e.g., 2024-12-31T23:59:59Z)")
+    .optional(),
 });
 
 export const SearchEventsArgumentsSchema = z.object({
   calendarId: z.string(),
   query: z.string(),
-  timeMin: z.string().optional(), 
-  timeMax: z.string().optional(),
+  timeMin: z.string()
+    .regex(isoDateTimeWithTimezone, "Must be ISO format with timezone (e.g., 2024-01-01T00:00:00Z)")
+    .optional(), 
+  timeMax: z.string()
+    .regex(isoDateTimeWithTimezone, "Must be ISO format with timezone (e.g., 2024-12-31T23:59:59Z)")
+    .optional(),
 });
 
 export const CreateEventArgumentsSchema = z.object({
   calendarId: z.string(),
   summary: z.string(),
   description: z.string().optional(),
-  start: z.string(), // Expecting ISO string
-  end: z.string(),   // Expecting ISO string
+  start: z.string().regex(isoDateTimeWithTimezone, "Must be ISO format with timezone (e.g., 2024-01-01T00:00:00Z)"), 
+  end: z.string().regex(isoDateTimeWithTimezone, "Must be ISO format with timezone (e.g., 2024-01-01T00:00:00Z)"),
   timeZone: z.string(),
   attendees: z
     .array(
@@ -50,8 +61,12 @@ export const UpdateEventArgumentsSchema = z.object({
   eventId: z.string(),
   summary: z.string().optional(),
   description: z.string().optional(),
-  start: z.string().optional(), // Expecting ISO string
-  end: z.string().optional(),   // Expecting ISO string
+  start: z.string()
+    .regex(isoDateTimeWithTimezone, "Must be ISO format with timezone (e.g., 2024-01-01T00:00:00Z)")
+    .optional(),
+  end: z.string()
+    .regex(isoDateTimeWithTimezone, "Must be ISO format with timezone (e.g., 2024-01-01T00:00:00Z)")
+    .optional(),
   timeZone: z.string(), // Required even if start/end don't change, per API docs for patch
   attendees: z
     .array(


### PR DESCRIPTION
Timezones are mandatory:
https://developers.google.com/workspace/calendar/api/v3/reference/events/list#parameters

Fixes #19