### PR TITLE
Token storage improvements and simplification

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -101,16 +101,16 @@ jobs:
           body: |
             ## Changes in this Release
             
-            - Package published to npm as `@nspady/google-calendar-mcp@${{ steps.package-version.outputs.version }}`
-            - Can be installed with: `npx @nspady/google-calendar-mcp@${{ steps.package-version.outputs.version }}`
+            - Package published to npm as `@cocal/google-calendar-mcp@${{ steps.package-version.outputs.version }}`
+            - Can be installed with: `npx @cocal/google-calendar-mcp@${{ steps.package-version.outputs.version }}`
             
             ### Installation
             ```bash
             # Install globally
-            npm install -g @nspady/google-calendar-mcp@${{ steps.package-version.outputs.version }}
+            npm install -g @cocal/google-calendar-mcp@${{ steps.package-version.outputs.version }}
             
             # Run directly with npx
-            npx @nspady/google-calendar-mcp@${{ steps.package-version.outputs.version }}
+            npx @cocal/google-calendar-mcp@${{ steps.package-version.outputs.version }}
             ```
             
             See the [CHANGELOG](CHANGELOG.md) for detailed changes.

--- a/README.md
+++ b/README.md
@@ -319,10 +319,17 @@ npm run auth
 
 ### Token Management
 
-- Authentication tokens are stored in `.gcp-saved-tokens.json` in the project root.
-- This file is created automatically and should **not** be committed to version control (it's included in `.gitignore`).
-- The server attempts to automatically refresh expired access tokens using the stored refresh token.
-- If the refresh token itself expires (e.g., after 7 days if the Google Cloud app is in testing mode) or is revoked, you will need to re-authenticate using either the automatic flow (by restarting the server) or the manual `npm run auth` command.
+- **Authentication tokens are stored in `~/.config/google-calendar-mcp/tokens.json`** following the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) (a cross-platform standard for organizing user configuration files)
+- On systems without XDG support, tokens are stored in `~/.config/google-calendar-mcp/tokens.json` 
+- **Custom token location**: Set `GOOGLE_CALENDAR_MCP_TOKEN_PATH` environment variable to use a different location
+- Token files are created automatically with secure permissions (600) and should **not** be committed to version control
+- The server attempts to automatically refresh expired access tokens using the stored refresh token
+- If the refresh token itself expires (e.g., after 7 days if the Google Cloud app is in testing mode) or is revoked, you will need to re-authenticate using either the automatic flow (by restarting the server) or the manual `npm run auth` command
+
+#### Token Storage Priority
+1. **Custom path**: `GOOGLE_CALENDAR_MCP_TOKEN_PATH` environment variable (highest priority)
+2. **XDG Config**: `$XDG_CONFIG_HOME/google-calendar-mcp/tokens.json` if XDG_CONFIG_HOME is set
+3. **Default**: `~/.config/google-calendar-mcp/tokens.json` (lowest priority)
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Along with the normal capabilities you would expect for a calendar integration y
 
 ### Option 1: Use with npx (Recommended)
 
-**Important**: When using npx, you **must** specify the credentials file path using either the `--credentials-file` parameter or the `GOOGLE_OAUTH_CREDENTIALS_FILE` environment variable.
+**Important**: When using npx, you **must** specify the credentials file path using either the `--credentials-file` parameter or the `GOOGLE_OAUTH_CREDENTIALS` environment variable.
 
 1. **Add to Claude Desktop**: Edit your Claude Desktop configuration file:
    
@@ -82,7 +82,7 @@ Along with the normal capabilities you would expect for a calendar integration y
      "mcpServers": {
        "google-calendar": {
          "command": "npx",
-         "args": ["@nspady/google-calendar-mcp", "start", "--credentials-file", "/path/to/your/gcp-oauth.keys.json"]
+         "args": ["@cocal/google-calendar-mcp"]
        }
      }
    }
@@ -94,9 +94,9 @@ Along with the normal capabilities you would expect for a calendar integration y
      "mcpServers": {
        "google-calendar": {
          "command": "npx",
-         "args": ["@nspady/google-calendar-mcp", "start"],
+         "args": ["@cocal/google-calendar-mcp"],
          "env": {
-           "GOOGLE_OAUTH_CREDENTIALS_FILE": "/path/to/your/gcp-oauth.keys.json"
+           "GOOGLE_OAUTH_CREDENTIALS": "/path/to/your/gcp-oauth.keys.json"
          }
        }
      }
@@ -123,7 +123,7 @@ Along with the normal capabilities you would expect for a calendar integration y
 
    **Option B: Custom file location**
    - Place your credentials file anywhere on your system
-   - Use the `--credentials-file` parameter or `GOOGLE_OAUTH_CREDENTIALS_FILE` environment variable to specify the path
+   - Use the `--credentials-file` parameter or `GOOGLE_OAUTH_CREDENTIALS` environment variable to specify the path
 
 4. **Add configuration to your Claude Desktop config file:**
 
@@ -163,7 +163,7 @@ Along with the normal capabilities you would expect for a calendar integration y
          "command": "node",
          "args": ["<absolute-path-to-project-folder>/build/index.js"],
          "env": {
-           "GOOGLE_OAUTH_CREDENTIALS_FILE": "/path/to/your/credentials.json"
+           "GOOGLE_OAUTH_CREDENTIALS": "/path/to/your/credentials.json"
          }
        }
      }
@@ -193,7 +193,7 @@ The server supports multiple methods for providing OAuth credentials, with a pri
 The server searches for OAuth credentials in the following order:
 
 1. **CLI Parameter** (Highest Priority): `--credentials-file` parameter
-2. **Environment Variable**: `GOOGLE_OAUTH_CREDENTIALS_FILE` environment variable
+2. **Environment Variable**: `GOOGLE_OAUTH_CREDENTIALS` environment variable
 3. **Default File** (Lowest Priority): `gcp-oauth.keys.json` in the current working directory
 
 ### Configuration Methods
@@ -203,22 +203,22 @@ Use the `--credentials-file` parameter to specify a custom path to your OAuth cr
 
 ```bash
 # For authentication
-npx @nspady/google-calendar-mcp auth --credentials-file /path/to/your/credentials.json
+npx @cocal/google-calendar-mcp auth --credentials-file /path/to/your/credentials.json
 
 # For starting the server
-npx @nspady/google-calendar-mcp start --credentials-file /path/to/your/credentials.json
+npx @cocal/google-calendar-mcp start --credentials-file /path/to/your/credentials.json
 ```
 
 #### Method 2: Environment Variable
-Set the `GOOGLE_OAUTH_CREDENTIALS_FILE` environment variable:
+Set the `GOOGLE_OAUTH_CREDENTIALS` environment variable:
 
 ```bash
 # Set environment variable
-export GOOGLE_OAUTH_CREDENTIALS_FILE="/path/to/your/credentials.json"
+export GOOGLE_OAUTH_CREDENTIALS="/path/to/your/credentials.json"
 
 # Then run normally
-npx @nspady/google-calendar-mcp auth
-npx @nspady/google-calendar-mcp start
+npx @cocal/google-calendar-mcp auth
+npx @cocal/google-calendar-mcp start
 ```
 
 #### Method 3: Default File
@@ -235,7 +235,7 @@ Choose one of these configuration methods based on your preference:
     "google-calendar": {
       "command": "npx",
       "args": [
-        "@nspady/google-calendar-mcp",
+        "@cocal/google-calendar-mcp",
         "start",
         "--credentials-file",
         "/Users/yourname/Documents/my-google-credentials.json"
@@ -251,9 +251,9 @@ Choose one of these configuration methods based on your preference:
   "mcpServers": {
     "google-calendar": {
       "command": "npx",
-      "args": ["@nspady/google-calendar-mcp", "start"],
+      "args": ["@cocal/google-calendar-mcp", "start"],
       "env": {
-        "GOOGLE_OAUTH_CREDENTIALS_FILE": "/Users/yourname/Documents/my-google-credentials.json"
+        "GOOGLE_OAUTH_CREDENTIALS": "/Users/yourname/Documents/my-google-credentials.json"
       }
     }
   }
@@ -270,7 +270,7 @@ The server handles Google OAuth 2.0 authentication to access your calendar data.
 
 1. **Ensure OAuth credentials are available** using one of the supported methods:
    - CLI parameter: `--credentials-file /path/to/credentials.json`
-   - Environment variable: `GOOGLE_OAUTH_CREDENTIALS_FILE=/path/to/credentials.json`
+   - Environment variable: `GOOGLE_OAUTH_CREDENTIALS=/path/to/credentials.json`
    - Default file: `gcp-oauth.keys.json` in the working directory
 
 2. **Start the MCP server** using your chosen method from the installation section above.
@@ -294,14 +294,14 @@ If you need to re-authenticate or prefer to handle authentication separately:
 **For npx installations:**
 ```bash
 # Using default credentials file location
-npx @nspady/google-calendar-mcp auth
+npx @cocal/google-calendar-mcp auth
 
 # Using custom credentials file path
-npx @nspady/google-calendar-mcp auth --credentials-file /path/to/your/credentials.json
+npx @cocal/google-calendar-mcp auth --credentials-file /path/to/your/credentials.json
 
 # Using environment variable
-export GOOGLE_OAUTH_CREDENTIALS_FILE="/path/to/your/credentials.json"
-npx @nspady/google-calendar-mcp auth
+export GOOGLE_OAUTH_CREDENTIALS="/path/to/your/credentials.json"
+npx @cocal/google-calendar-mcp auth
 ```
 
 **For local installations:**
@@ -360,14 +360,14 @@ Tests mock external dependencies (Google API, filesystem) to ensure isolated tes
    **Option A: Use CLI Parameter (Recommended for npx)**
    ```bash
    # For authentication
-   npx @nspady/google-calendar-mcp auth --credentials-file /path/to/your/credentials.json
+   npx @cocal/google-calendar-mcp auth --credentials-file /path/to/your/credentials.json
    
    # Update Claude Desktop config to use CLI parameter:
    {
      "mcpServers": {
        "google-calendar": {
          "command": "npx",
-         "args": ["@nspady/google-calendar-mcp", "start", "--credentials-file", "/path/to/your/credentials.json"]
+         "args": ["@cocal/google-calendar-mcp", "start", "--credentials-file", "/path/to/your/credentials.json"]
        }
      }
    }
@@ -376,16 +376,16 @@ Tests mock external dependencies (Google API, filesystem) to ensure isolated tes
    **Option B: Use Environment Variable**
    ```bash
    # Set environment variable
-   export GOOGLE_OAUTH_CREDENTIALS_FILE="/path/to/your/credentials.json"
+   export GOOGLE_OAUTH_CREDENTIALS="/path/to/your/credentials.json"
    
    # Update Claude Desktop config to use environment variable:
    {
      "mcpServers": {
        "google-calendar": {
          "command": "npx",
-         "args": ["@nspady/google-calendar-mcp", "start"],
+         "args": ["@cocal/google-calendar-mcp", "start"],
          "env": {
-           "GOOGLE_OAUTH_CREDENTIALS_FILE": "/path/to/your/credentials.json"
+           "GOOGLE_OAUTH_CREDENTIALS": "/path/to/your/credentials.json"
          }
        }
      }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
       "dependencies": {
         "@google-cloud/local-auth": "^3.0.1",
         "@modelcontextprotocol/sdk": "^1.0.3",
-        "@types/express": "^4.17.21",
         "esbuild": "^0.25.0",
         "express": "^4.18.2",
         "google-auth-library": "^9.15.0",
@@ -24,6 +23,7 @@
         "google-calendar-mcp": "build/index.js"
       },
       "devDependencies": {
+        "@types/express": "^5.0.2",
         "@types/node": "^20.10.4",
         "@vitest/coverage-v8": "^3.1.1",
         "typescript": "^5.3.3",
@@ -881,6 +881,7 @@
       "version": "1.19.5",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
       "integrity": "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/connect": "*",
@@ -891,6 +892,7 @@
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -904,21 +906,22 @@
       "license": "MIT"
     },
     "node_modules/@types/express": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
-      "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.2.tgz",
+      "integrity": "sha512-BtjL3ZwbCQriyb0DGw+Rt12qAXPiBTPs815lsUvtt1Grk0vLRMZNMUZ741d5rjk+UQOxfDiBZ3dxpX00vSkK3g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^4.17.33",
-        "@types/qs": "*",
+        "@types/express-serve-static-core": "^5.0.0",
         "@types/serve-static": "*"
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "4.19.6",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.6.tgz",
-      "integrity": "sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.6.tgz",
+      "integrity": "sha512-3xhRnjJPkULekpSzgtoNYYcTWgEZkp4myc+Saevii5JPnHNvHMRlBSHDbs7Bh1iPPoVTERHEZXyhyLbMEsExsA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -931,39 +934,45 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
       "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "20.17.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.9.tgz",
       "integrity": "sha512-0JOXkRyLanfGPE2QRCwgxhzlBAvaRdCNMcvbd7jFfpmD4eEXll7LRwy5ymJmyeZqk7Nh7eD2LeUyQ68BbndmXw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
       }
     },
     "node_modules/@types/qs": {
-      "version": "6.9.17",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.17.tgz",
-      "integrity": "sha512-rX4/bPcfmvxHDv0XjfJELTTr+iB+tn032nPILqHm5wbthUUUuVtNGGqzhya9XUxjTP8Fpr0qYgSZZKxGY++svQ==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/send": {
       "version": "0.17.4",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
       "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mime": "^1",
@@ -974,6 +983,7 @@
       "version": "1.15.7",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.7.tgz",
       "integrity": "sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/http-errors": "*",
@@ -3221,6 +3231,7 @@
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
   "dependencies": {
     "@google-cloud/local-auth": "^3.0.1",
     "@modelcontextprotocol/sdk": "^1.0.3",
-    "@types/express": "^4.17.21",
     "esbuild": "^0.25.0",
     "express": "^4.18.2",
     "google-auth-library": "^9.15.0",
@@ -53,6 +52,7 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
+    "@types/express": "^5.0.2",
     "@types/node": "^20.10.4",
     "@vitest/coverage-v8": "^3.1.1",
     "typescript": "^5.3.3",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "@nspady/google-calendar-mcp",
-  "version": "1.2.0-beta.0",
+  "name": "@cocal/google-calendar-mcp",
+  "version": "1.2.0-beta.3",
   "description": "Google Calendar MCP Server",
   "type": "module",
   "bin": {
-    "google-calendar-mcp": "./build/index.js"
+    "google-calendar-mcp": "build/index.js"
   },
   "files": [
     "build/",
@@ -36,7 +36,6 @@
     "build": "npm run typecheck && node scripts/build.js",
     "start": "node build/index.js",
     "auth": "node build/auth-server.js",
-    "postinstall": "scripts/build.js",
     "test": "vitest run",
     "test:watch": "vitest",
     "coverage": "vitest run --coverage"

--- a/src/auth-server.ts
+++ b/src/auth-server.ts
@@ -1,29 +1,5 @@
 import { initializeOAuth2Client } from './auth/client.js';
 import { AuthServer } from './auth/server.js';
-import { setCredentialsPath } from './auth/utils.js';
-
-// Parse CLI arguments for credentials
-function parseAuthServerArgs(): { credentialsPath: string | undefined } {
-  const args = process.argv.slice(2);
-  let credentialsPath: string | undefined;
-
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i];
-    
-    // Check for credentials file option
-    if (arg === '--credentials-file') {
-      if (i + 1 < args.length && !args[i + 1].startsWith('--')) {
-        credentialsPath = args[i + 1];
-        i++; // Skip the next argument as it's the value
-      } else {
-        console.error(`Option ${arg} requires a value`);
-        process.exit(1);
-      }
-    }
-  }
-
-  return { credentialsPath };
-}
 
 // Main function to run the authentication server
 async function runAuthServer() {
@@ -79,12 +55,6 @@ async function runAuthServer() {
 
 // Run the auth server if this file is executed directly
 if (import.meta.url.endsWith('auth-server.js')) {
-  // Parse CLI arguments and set credentials path if provided
-  const { credentialsPath } = parseAuthServerArgs();
-  if (credentialsPath) {
-    setCredentialsPath(credentialsPath);
-  }
-  
   runAuthServer().catch((error: unknown) => {
     process.stderr.write(`Unhandled error: ${error instanceof Error ? error.message : 'Unknown error'}\n`);
     process.exit(1);

--- a/src/auth/utils.ts
+++ b/src/auth/utils.ts
@@ -2,9 +2,6 @@ import * as path from 'path';
 import * as os from 'os';
 import { fileURLToPath } from 'url';
 
-// Global variable to store CLI-provided credentials path
-let cliCredentialsPath: string | undefined;
-
 // Helper to get the project root directory reliably
 function getProjectRoot(): string {
   const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -12,11 +9,6 @@ function getProjectRoot(): string {
   // Go up ONE level to get the project root
   const projectRoot = path.join(__dirname, ".."); // Corrected: Go up ONE level
   return path.resolve(projectRoot); // Ensure absolute path
-}
-
-// Set the credentials path from CLI arguments
-export function setCredentialsPath(credentialsPath: string): void {
-  cliCredentialsPath = credentialsPath;
 }
 
 // Returns the absolute path for the saved token file.
@@ -43,22 +35,16 @@ export function getLegacyTokenPath(): string {
 }
 
 // Returns the absolute path for the GCP OAuth keys file with priority:
-// 1. CLI parameter (highest priority)
-// 2. Environment variable GOOGLE_OAUTH_CREDENTIALS_FILE
-// 3. Default file path (lowest priority)
+// 1. Environment variable GOOGLE_OAUTH_CREDENTIALS (highest priority)
+// 2. Default file path (lowest priority)
 export function getKeysFilePath(): string {
-  // Priority 1: CLI parameter
-  if (cliCredentialsPath) {
-    return path.resolve(cliCredentialsPath);
-  }
-  
-  // Priority 2: Environment variable
-  const envCredentialsPath = process.env.GOOGLE_OAUTH_CREDENTIALS_FILE;
+  // Priority 1: Environment variable
+  const envCredentialsPath = process.env.GOOGLE_OAUTH_CREDENTIALS;
   if (envCredentialsPath) {
     return path.resolve(envCredentialsPath);
   }
   
-  // Priority 3: Default file path
+  // Priority 2: Default file path
   const projectRoot = getProjectRoot();
   const keysPath = path.join(projectRoot, "gcp-oauth.keys.json");
   return keysPath; // Already absolute from getProjectRoot
@@ -76,14 +62,11 @@ export function generateCredentialsErrorMessage(): string {
   return `
 OAuth credentials not found. Please provide credentials using one of these methods:
 
-1. CLI parameter:
-   npx @nspady/google-calendar-mcp auth --credentials-file /path/to/gcp-oauth.keys.json
+1. Environment variable:
+   Set GOOGLE_OAUTH_CREDENTIALS to the path of your credentials file:
+   export GOOGLE_OAUTH_CREDENTIALS="/path/to/gcp-oauth.keys.json"
 
-2. Environment variable:
-   Set GOOGLE_OAUTH_CREDENTIALS_FILE to the path of your credentials file:
-   export GOOGLE_OAUTH_CREDENTIALS_FILE="/path/to/gcp-oauth.keys.json"
-
-3. Default file path:
+2. Default file path:
    Place your gcp-oauth.keys.json file in the package root directory.
 
 Token storage:

--- a/src/auth/utils.ts
+++ b/src/auth/utils.ts
@@ -1,4 +1,5 @@
 import * as path from 'path';
+import * as os from 'os';
 import { fileURLToPath } from 'url';
 
 // Global variable to store CLI-provided credentials path
@@ -19,10 +20,26 @@ export function setCredentialsPath(credentialsPath: string): void {
 }
 
 // Returns the absolute path for the saved token file.
+// Uses XDG Base Directory spec with fallback to home directory and legacy project root
 export function getSecureTokenPath(): string {
+  // Check for custom token path environment variable first
+  const customTokenPath = process.env.GOOGLE_CALENDAR_MCP_TOKEN_PATH;
+  if (customTokenPath) {
+    return path.resolve(customTokenPath);
+  }
+
+  // Use XDG Base Directory spec or fallback to ~/.config
+  const configHome = process.env.XDG_CONFIG_HOME || 
+    path.join(os.homedir(), '.config');
+  
+  const tokenDir = path.join(configHome, 'google-calendar-mcp');
+  return path.join(tokenDir, 'tokens.json');
+}
+
+// Returns the legacy token path for backward compatibility
+export function getLegacyTokenPath(): string {
   const projectRoot = getProjectRoot();
-  const tokenPath = path.join(projectRoot, ".gcp-saved-tokens.json");
-  return tokenPath; // Already absolute from getProjectRoot
+  return path.join(projectRoot, ".gcp-saved-tokens.json");
 }
 
 // Returns the absolute path for the GCP OAuth keys file with priority:
@@ -68,6 +85,10 @@ OAuth credentials not found. Please provide credentials using one of these metho
 
 3. Default file path:
    Place your gcp-oauth.keys.json file in the package root directory.
+
+Token storage:
+- Tokens are saved to: ${getSecureTokenPath()}
+- To use a custom token location, set GOOGLE_CALENDAR_MCP_TOKEN_PATH environment variable
 
 To get OAuth credentials:
 1. Go to the Google Cloud Console (https://console.cloud.google.com/)


### PR DESCRIPTION
## Summary

  - **Migrate token storage** to XDG
  standard (`~/.config/google-calendar-mcp/tokens.json`) with automatic migration from legacy location
  - **Update package name** from `@nspady/google-calendar-mcp` to `@cocal/google-calendar-mcp` (v1.2.0-beta.3)
  - **Simplify credential configuration** to use `GOOGLE_OAUTH_CREDENTIALS` environment variable, removing CLI parameter support

  ## Test plan

  - [x] Token migration works correctly
  - [x] New credential configuration
  functions properly
  - [x] Authentication and MCP server
  functionality verified