### PR TITLE
Add valid main entrypoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.4.8",
   "description": "Google Calendar MCP Server with extensive support for calendar management",
   "type": "module",
+  "main": "build/index.js",
   "bin": {
     "google-calendar-mcp": "build/index.js"
   },


### PR DESCRIPTION
**Main changes**
- If someone wants to get this package executable path by using `require.resolve` - So far it would fail as the package.json wouldn't hold a valid `main` entrypoint.

This PR adds one

Resolves: https://github.com/nspady/google-calendar-mcp/issues/66