### PR TITLE
Include colorId in list-events response

### DIFF
--- a/src/handlers/utils.ts
+++ b/src/handlers/utils.ts
@@ -97,7 +97,8 @@ export function formatEventWithDetails(event: calendar_v3.Schema$Event, calendar
     const eventId = event.id ? `\nEvent ID: ${event.id}` : "";
     const description = event.description ? `\nDescription: ${event.description}` : "";
     const location = event.location ? `\nLocation: ${event.location}` : "";
-    
+    const colorId = event.colorId ? `\nColor ID: ${event.colorId}` : "";
+
     // Format start and end times with timezone
     const startTime = formatDateTime(event.start?.dateTime, event.start?.date, event.start?.timeZone || undefined);
     const endTime = formatDateTime(event.end?.dateTime, event.end?.date, event.end?.timeZone || undefined);
@@ -134,6 +135,6 @@ export function formatEventWithDetails(event: calendar_v3.Schema$Event, calendar
     const eventUrl = getEventUrl(event, calendarId);
     const urlInfo = eventUrl ? `\nView: ${eventUrl}` : "";
     
-    return `${title}${eventId}${description}${timeInfo}${location}${attendeeInfo}${urlInfo}`;
+    return `${title}${eventId}${description}${timeInfo}${location}${colorId}${attendeeInfo}${urlInfo}`;
 }
 


### PR DESCRIPTION
### **Description:**

This PR enhances the list-events function so that the returned event objects now include the colorId field from the Google Calendar API v3.

### **Changes made:**

File: _src/utils.ts_

Function: _formatEventWithDetails_

**Added colorId to the returned event object so that event color information is included alongside other details.**

### **_Why this change is useful:_**

1. Enables visual organization and categorization of events.
2. Supports workflows that rely on color-based filtering.
3. Aligns returned data with the Google Calendar API v3’s full event resource.