### PR TITLE
Fix all-day event handling (fixes #83)

### DIFF
--- a/src/handlers/utils/datetime.ts
+++ b/src/handlers/utils/datetime.ts
@@ -93,11 +93,20 @@ function convertLocalTimeToUTC(year: number, month: number, day: number, hour: n
 
 /**
  * Creates a time object for Google Calendar API, handling both timezone-aware and timezone-naive datetime strings
+ * Also handles all-day events by using 'date' field instead of 'dateTime'
  * @param datetime ISO 8601 datetime string (with or without timezone)
  * @param fallbackTimezone Timezone to use if datetime is timezone-naive (IANA format)
  * @returns Google Calendar API time object
  */
-export function createTimeObject(datetime: string, fallbackTimezone: string): { dateTime: string; timeZone?: string } {
+export function createTimeObject(datetime: string, fallbackTimezone: string): { dateTime?: string; date?: string; timeZone?: string } {
+    // Check if this is a date-only string (all-day event)
+    // Date-only format: YYYY-MM-DD (no time component)
+    if (!/T/.test(datetime)) {
+        // This is a date-only string, use the 'date' field for all-day event
+        return { date: datetime };
+    }
+    
+    // This is a datetime string with time component
     if (hasTimezoneInDatetime(datetime)) {
         // Timezone included in datetime - use as-is, no separate timeZone property needed
         return { dateTime: datetime };

--- a/src/tests/integration/test-data-factory.ts
+++ b/src/tests/integration/test-data-factory.ts
@@ -6,7 +6,7 @@ export interface TestEvent {
   description?: string;
   start: string;
   end: string;
-  timeZone: string;
+  timeZone?: string; // Optional for all-day events
   location?: string;
   attendees?: Array<{ email: string }>;
   colorId?: string;
@@ -78,18 +78,20 @@ export class TestDataFactory {
   static createAllDayEvent(overrides: Partial<TestEvent> = {}): TestEvent {
     const tomorrow = new Date();
     tomorrow.setDate(tomorrow.getDate() + 1);
-    tomorrow.setHours(0, 0, 0, 0);
     
     const dayAfter = new Date(tomorrow);
     dayAfter.setDate(dayAfter.getDate() + 1);
-    dayAfter.setHours(0, 0, 0, 0);
+
+    // For all-day events, use date-only format (YYYY-MM-DD)
+    const startDate = tomorrow.toISOString().split('T')[0];
+    const endDate = dayAfter.toISOString().split('T')[0];
 
     return {
       summary: 'Test All-Day Event',
       description: 'All-day test event',
-      start: this.formatDateTimeRFC3339(tomorrow),
-      end: this.formatDateTimeRFC3339(dayAfter),
-      timeZone: 'America/Los_Angeles',
+      start: startDate,
+      end: endDate,
+      // Note: timeZone is not used for all-day events (they're date-only)
       ...overrides
     };
   }
@@ -173,7 +175,7 @@ export class TestDataFactory {
   }
 
   // Performance tracking
-  startTimer(operation: string): number {
+  startTimer(_operation: string): number {
     return Date.now();
   }
 

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -116,18 +116,20 @@ export const ToolSchemas = {
     description: z.string().optional().describe("Description/notes for the event"),
     start: z.string()
       .refine((val) => {
+        const dateOnly = /^\d{4}-\d{2}-\d{2}$/.test(val); // All-day event format
         const withTimezone = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(Z|[+-]\d{2}:\d{2})$/.test(val);
         const withoutTimezone = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/.test(val);
-        return withTimezone || withoutTimezone;
-      }, "Must be ISO 8601 format: '2026-01-01T00:00:00'")
-      .describe("Event start time: '2024-01-01T10:00:00'"),
+        return dateOnly || withTimezone || withoutTimezone;
+      }, "Must be ISO 8601 format: '2025-01-01T10:00:00' for timed events or '2025-01-01' for all-day events")
+      .describe("Event start time: '2025-01-01T10:00:00' for timed events or '2025-01-01' for all-day events"),
     end: z.string()
       .refine((val) => {
+        const dateOnly = /^\d{4}-\d{2}-\d{2}$/.test(val); // All-day event format
         const withTimezone = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(Z|[+-]\d{2}:\d{2})$/.test(val);
         const withoutTimezone = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/.test(val);
-        return withTimezone || withoutTimezone;
-      }, "Must be ISO 8601 format: '2026-01-01T00:00:00'")
-      .describe("Event end time: '2024-01-01T11:00:00'"),
+        return dateOnly || withTimezone || withoutTimezone;
+      }, "Must be ISO 8601 format: '2025-01-01T11:00:00' for timed events or '2025-01-02' for all-day events")
+      .describe("Event end time: '2025-01-01T11:00:00' for timed events or '2025-01-02' for all-day events (exclusive)"),
     timeZone: z.string().optional().describe(
       "Timezone as IANA Time Zone Database name (e.g., America/Los_Angeles). Takes priority over calendar's default timezone. Only used for timezone-naive datetime strings."
     ),
@@ -227,19 +229,21 @@ export const ToolSchemas = {
     description: z.string().optional().describe("Updated description/notes"),
     start: z.string()
       .refine((val) => {
+        const dateOnly = /^\d{4}-\d{2}-\d{2}$/.test(val); // All-day event format
         const withTimezone = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(Z|[+-]\d{2}:\d{2})$/.test(val);
         const withoutTimezone = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/.test(val);
-        return withTimezone || withoutTimezone;
-      }, "Must be ISO 8601 format: '2026-01-01T00:00:00'")
-      .describe("Updated start time: '2024-01-01T10:00:00'")
+        return dateOnly || withTimezone || withoutTimezone;
+      }, "Must be ISO 8601 format: '2024-01-01T10:00:00' for timed events or '2024-01-01' for all-day events")
+      .describe("Updated start time: '2024-01-01T10:00:00' for timed events or '2024-01-01' for all-day events")
       .optional(),
     end: z.string()
       .refine((val) => {
+        const dateOnly = /^\d{4}-\d{2}-\d{2}$/.test(val); // All-day event format
         const withTimezone = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(Z|[+-]\d{2}:\d{2})$/.test(val);
         const withoutTimezone = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/.test(val);
-        return withTimezone || withoutTimezone;
-      }, "Must be ISO 8601 format: '2026-01-01T00:00:00'")
-      .describe("Updated end time: '2024-01-01T11:00:00'")
+        return dateOnly || withTimezone || withoutTimezone;
+      }, "Must be ISO 8601 format: '2024-01-01T11:00:00' for timed events or '2024-01-02' for all-day events")
+      .describe("Updated end time: '2024-01-01T11:00:00' for timed events or '2024-01-02' for all-day events (exclusive)")
       .optional(),
     timeZone: z.string().optional().describe("Updated timezone as IANA Time Zone Database name. If not provided, uses the calendar's default timezone."),
     location: z.string().optional().describe("Updated location"),


### PR DESCRIPTION
  - Support date-only format (YYYY-MM-DD) for all-day events
  - Remove machine timezone dependency in date formatting
  - Update schema validation to accept both date and datetime formats
  - Fix all-day events displaying 1 day earlier in non-UTC timezones