### PR TITLE
Improve Docker deployment documentation and setup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,5 +213,18 @@ The codebase uses a structured response format for tool outputs. Recent commits 
 ## Deployment
 
 - **npx**: `npx @cocal/google-calendar-mcp` (requires `GOOGLE_OAUTH_CREDENTIALS` env var)
-- **Docker**: See `docs/docker.md` for Docker deployment with both stdio and HTTP modes
-- **Claude Desktop Config**: See README.md for configuration examples
+- **Docker**: See `docs/docker.md` for Docker deployment with stdio and HTTP modes
+- **Claude Desktop Config**: See README.md for local stdio configuration
+
+### Deployment Modes
+
+**Local Development (Claude Desktop):**
+- Use **stdio mode** (default)
+- No server or domain required
+- Direct process communication
+- See README.md for setup
+
+**Key Differences:**
+- **stdio**: For Claude Desktop only, local machine
+- **HTTP**: For testing, development, debugging (local only)
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,10 +9,7 @@ services:
     
     # Environment configuration via .env file
     env_file: .env
-    
-    # Keep container running for exec commands (stdio mode)
-    command: ["tail", "-f", "/dev/null"]
-    
+
     # OAuth credentials and token storage
     volumes:
       - ./gcp-oauth.keys.json:/app/gcp-oauth.keys.json:ro

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -5,20 +5,25 @@ Simple, production-ready Docker setup for the Google Calendar MCP Server. Follow
 ## Quick Start 
 
 ```bash
-# 1. Place OAuth credentials in project root 
-# * optional if you have already place the file in the root of this project folder
+# 1. Place OAuth credentials in project root
+# * optional if you have already placed the file in the root of this project folder
 cp /path/to/your/gcp-oauth.keys.json ./gcp-oauth.keys.json
 
-# 2. Copy example .env file to configure environment variables (optional)
+# Ensure the file has correct permissions for Docker to read
+chmod 644 ./gcp-oauth.keys.json
+
+# 2. Configure environment (optional - uses stdio mode by default)
+# The .env.example file contains all defaults. Copy if customization needed:
 cp .env.example .env
 
 # 3. Build and start the server
 docker compose up -d
 
 # 4. Authenticate (one-time setup)
-# This will show the authentication URL that needs to be 
-# visited to give authorization to the applicaiton. 
+# This will show the authentication URL that needs to be
+# visited to give authorization to the application.
 # Visit the URL and complete the OAuth process.
+# Note: This runs the built auth-server.js (build happens during docker build)
 docker compose exec calendar-mcp npm run auth
 # Note: This step only needs to be done once unless the app is in testing mode
 # in which case the tokens expire after 7 days 
@@ -27,6 +32,8 @@ docker compose exec calendar-mcp npm run auth
 ```
 
 ## Two Modes
+
+The server supports two transport modes: **stdio** (for local Claude Desktop) and **HTTP** (for remote/web access).
 
 ### stdio Mode (Recommended for Claude Desktop)
 **Direct process integration for Claude Desktop:**
@@ -40,10 +47,14 @@ cd google-calendar-mcp
 # Place your OAuth credentials in the project root
 cp /path/to/your/gcp-oauth.keys.json ./gcp-oauth.keys.json
 
+# Ensure the file has correct permissions for Docker to read
+chmod 644 ./gcp-oauth.keys.json
+
 # Build and start the container
 docker compose up -d
 
 # Authenticate (one-time setup)
+# Note: This runs the built auth-server.js (build happens during docker build)
 docker compose exec calendar-mcp npm run auth
 ```
 
@@ -62,7 +73,7 @@ Add to your Claude Desktop config file:
         "run", "--rm", "-i",
         "--mount", "type=bind,src=/absolute/path/to/your/gcp-oauth.keys.json,dst=/app/gcp-oauth.keys.json",
         "--mount", "type=volume,src=google-calendar-mcp_calendar-tokens,dst=/home/nodejs/.config/google-calendar-mcp",
-        "google-calendar-mcp-calendar-mcp"
+        "calendar-mcp"
       ]
     }
   }
@@ -86,13 +97,16 @@ cd google-calendar-mcp
 # Place your OAuth credentials in the project root
 cp /path/to/your/gcp-oauth.keys.json ./gcp-oauth.keys.json
 
+# Ensure the file has correct permissions for Docker to read
+chmod 644 ./gcp-oauth.keys.json
+
 # Configure for HTTP mode
+# Copy .env.example which has defaults (TRANSPORT=stdio, HOST=0.0.0.0, PORT=3000)
 cp .env.example .env
-# Edit .env to set:
-echo "TRANSPORT=http" >> .env
-echo "HOST=0.0.0.0" >> .env
-echo "PORT=3000" >> .env
-echo "GOOGLE_OAUTH_CREDENTIALS=./gcp-oauth.keys.json" >> .env
+
+# Change TRANSPORT to http (other defaults are already correct)
+# Update TRANSPORT=stdio to TRANSPORT=http in .env
+
 ```
 
 #### Step 2: Start and Authenticate
@@ -101,6 +115,7 @@ echo "GOOGLE_OAUTH_CREDENTIALS=./gcp-oauth.keys.json" >> .env
 docker compose up -d
 
 # Authenticate (one-time setup)
+# Note: This runs the built auth-server.js (build happens during docker build)
 docker compose exec calendar-mcp npm run auth
 # This will show authentication URLs (visit the displayed URL)
 # This step only needs to be done once unless the app is in testing mode
@@ -108,7 +123,7 @@ docker compose exec calendar-mcp npm run auth
 
 # Verify server is running
 curl http://localhost:3000/health
-# Should return: {"status":"healthy","server":"google-calendar-mcp","version":"1.3.0"}
+# Should return: {"status":"healthy","server":"google-calendar-mcp","timestamp":"YYYY-MM-DDT00:00:00.000"}
 ```
 
 #### Step 3: Test with cURL Example
@@ -138,3 +153,17 @@ Add to your Claude Desktop config file:
 ```
 
 **Note**: HTTP mode requires the container to be running (`docker compose up -d`)
+
+## Development: Updating Code
+
+If you modify the source code and want to see your changes reflected in the Docker container:
+
+```bash
+# Rebuild the Docker image and restart the container
+docker compose build && docker compose up -d
+
+# Verify changes are applied (check timestamp updates)
+curl http://localhost:3000/health
+```
+
+**Why rebuild?** The Docker image contains a built snapshot of your code. Changes to source files won't appear until you rebuild the image with `docker compose build`.

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -19,14 +19,14 @@ export class HttpTransportHandler {
   async connect(): Promise<void> {
     const port = this.config.port || 3000;
     const host = this.config.host || '127.0.0.1';
-    
+
     // Configure transport for stateless mode to allow multiple initialization cycles
     const transport = new StreamableHTTPServerTransport({
       sessionIdGenerator: undefined // Stateless mode - allows multiple initializations
     });
 
     await this.server.connect(transport);
-    
+
     // Create HTTP server to handle the StreamableHTTP transport
     const httpServer = http.createServer(async (req, res) => {
       // Validate Origin header to prevent DNS rebinding attacks (MCP spec requirement)
@@ -34,10 +34,10 @@ export class HttpTransportHandler {
       const allowedOrigins = [
         'http://localhost',
         'http://127.0.0.1',
-        'https://localhost', 
+        'https://localhost',
         'https://127.0.0.1'
       ];
-      
+
       // For requests with Origin header, validate it
       if (origin && !allowedOrigins.some(allowed => origin.startsWith(allowed))) {
         res.writeHead(403, { 'Content-Type': 'application/json' });
@@ -90,7 +90,6 @@ export class HttpTransportHandler {
         res.end(JSON.stringify({
           status: 'healthy',
           server: 'google-calendar-mcp',
-          version: '1.3.0',
           timestamp: new Date().toISOString()
         }));
         return;

--- a/src/utils/response-builder.ts
+++ b/src/utils/response-builder.ts
@@ -10,12 +10,17 @@ import { calendar_v3 } from "googleapis";
 
 /**
  * Creates a structured JSON response for MCP tools
+ *
+ * Note: We use compact JSON (no pretty-printing) because MCP clients
+ * are expected to parse and display the JSON themselves. Pretty-printing
+ * with escaped newlines (\n) creates poor display in clients that show
+ * the raw text.
  */
 export function createStructuredResponse<T>(data: T): CallToolResult {
   return {
     content: [{
       type: "text",
-      text: JSON.stringify(data, null, 2)
+      text: JSON.stringify(data)
     }]
   };
 }


### PR DESCRIPTION
## Summary
- Clarified Docker deployment modes (stdio vs HTTP) in docs and CLAUDE.md
- Fixed Docker setup instructions with proper permission handling
- Improved cURL example script to cleanly parse structured JSON responses
- Removed hardcoded version from health endpoint (uses timestamp instead)
- Switched to compact JSON output for better MCP client display

## Changes
- **docs/docker.md**: Enhanced deployment guide with clearer mode explanations, permission fixes, and rebuild instructions
- **CLAUDE.md**: Added deployment modes section clarifying stdio vs HTTP usage
- **examples/http-with-curl.sh**: Updated to properly parse nested JSON responses
- **docker-compose.yml**: Removed unused tail command
- **src/transports/http.ts**: Removed hardcoded version from health check
- **src/utils/response-builder.ts**: Changed to compact JSON (no pretty-printing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)