### PR TITLE
Accept native array format for calendarId in list-events (fixes #95)

### DIFF
--- a/src/tests/unit/handlers/BatchListEvents.test.ts
+++ b/src/tests/unit/handlers/BatchListEvents.test.ts
@@ -80,16 +80,16 @@ describe('Batch List Events Functionality', () => {
     });
 
     it('should accept actual array of calendar IDs (not JSON string)', () => {
-      // In the new schema, arrays are not directly supported - they must be JSON strings
+      // Arrays are now directly supported and converted to JSON strings
       const input = {
         calendarId: ['primary', 'work@example.com', 'personal@example.com'],
         timeMin: '2024-01-01T00:00:00Z'
       };
 
       const result = ListEventsArgumentsSchema.safeParse(input);
-      // Arrays are no longer accepted directly
-      expect(result.success).toBe(false);
-      expect(result.error?.issues[0].message).toContain('Expected string');
+      expect(result.success).toBe(true);
+      // The transform converts arrays to JSON strings
+      expect(result.data?.calendarId).toBe('["primary","work@example.com","personal@example.com"]');
     });
 
     it('should handle malformed JSON string gracefully', () => {

--- a/src/tests/unit/schemas/validators.test.ts
+++ b/src/tests/unit/schemas/validators.test.ts
@@ -372,15 +372,16 @@ describe('ListEventsArgumentsSchema JSON String Handling', () => {
   });
 
   it('should handle regular array calendarId', () => {
-    // Arrays are no longer directly supported - they must be JSON strings
+    // Arrays are now supported via preprocessing
     const input = {
       calendarId: ['primary', 'secondary@gmail.com'],
       timeMin: '2024-01-01T00:00:00Z',
       timeMax: '2024-01-02T00:00:00Z'
     };
 
-    // This should now throw because arrays aren't accepted directly
-    expect(() => ListEventsArgumentsSchema.parse(input)).toThrow();
+    // The preprocess function converts the array to a JSON string
+    const result = ListEventsArgumentsSchema.parse(input);
+    expect(result.calendarId).toBe('["primary","secondary@gmail.com"]');
   });
 
   it('should reject invalid JSON string', () => {


### PR DESCRIPTION
## Problem

When LLMs send `calendarId` as a native array (e.g., from Home Assistant's multi-mcp integration), the `list-events` tool fails with validation error:

```
MCP error -32602: Invalid arguments for tool list-events: 
Expected string, received array
```

**Example from issue #95:**
```json
{
  "calendarId": ["primary", "work@example.com", "personal@example.com", "family@example.com", "events@example.com"],
  "timeMin": "2025-10-09T00:00:00",
  "timeMax": "2025-10-09T23:59:59"
}
```

## Solution

Implements dual-schema approach to accept arrays while maintaining OpenAI compatibility:

1. **Runtime validation schema**: Uses `z.union([string, array])` to accept both formats, validates array constraints (max 50, no duplicates), and transforms arrays to JSON strings
2. **MCP registration schema**: Shows string-only schema to avoid `anyOf` which breaks OpenAI compatibility

## Supported Formats

All three formats now work:
- ✅ Native array: `['cal1', 'cal2']` (fixes #95)
- ✅ Single string: `'primary'` (backward compatible)
- ✅ JSON string: `'["cal1", "cal2"]'` (original workaround)

## Testing

- All 343 unit tests pass
- Schema compatibility tests pass (no `anyOf`/`oneOf` in registered schemas)
- Validated with exact input from issue #95

Fixes #95