### PR TITLE
fix: Add quota project header support with centralized credential handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,12 @@ Along with the normal capabilities you would expect for a calendar integration y
    - Perform manual authentication per the below steps
    - Use a Chromium-based browser to open the authentication URL. Test app authentication may not be supported on some non-Chromium browsers.
 
+5. **"User Rate Limit Exceeded" errors**
+   - This typically occurs when your OAuth credentials are missing project information
+   - Ensure your `gcp-oauth.keys.json` file includes `project_id`
+   - Re-download credentials from Google Cloud Console if needed
+   - The file should have format: `{"installed": {"project_id": "your-project-id", ...}}`
+
 ### Manual Authentication
 For re-authentication or troubleshooting:
 ```bash


### PR DESCRIPTION
## Summary

Addresses issue where OAuth users experience 'User Rate Limit Exceeded' errors due to missing quota project attribution. This fix implements proper quota project headers using a centralized credential management approach.

## Changes Made

### Core Fix
- **Added `getCredentialsProjectId()` helper to [src/auth/utils.ts](src/auth/utils.ts)**
  - Centralizes credential file path logic using existing `getKeysFilePath()`
  - Uses ESM imports (`fs`) instead of `require()` for bundle compatibility
  - Supports both installed and direct credential formats
  - Gracefully handles missing `project_id` for backward compatibility

- **Updated [BaseToolHandler.ts](src/handlers/core/BaseToolHandler.ts)**
  - Automatically configures Google Calendar API client with `quotaProjectId`
  - Adds `x-goog-user-project` header to all API requests
  - Enhanced error handling for 'User Rate Limit Exceeded' with troubleshooting guidance

### Documentation
- **Updated [README.md](README.md)** with troubleshooting section for quota-related rate limit errors

## Implementation Details

This implementation addresses the review feedback from PR #90:
1. ✅ Uses centralized `getKeysFilePath()` instead of duplicating credential path logic
2. ✅ Uses proper ESM imports instead of `require()` to avoid bundle issues

## Testing

- ✅ All existing unit tests pass (343 tests)
- ✅ Build succeeds with no errors
- ✅ Backward compatible with existing credential files
- ✅ Graceful handling when `project_id` is missing

## Impact

This fix resolves the quota attribution issue for all OAuth users while maintaining full backward compatibility. Users with proper OAuth credentials (including `project_id`) will no longer experience 'User Rate Limit Exceeded' errors.

## Related

Incorporates and improves upon changes from PR #90 by @louspringer