### PR TITLE
fix: Resolve rollup optional dependency issue in CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,10 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
-        run: npm ci
+        run: |
+          npm ci
+          # Force reinstall optional dependencies (fixes rollup platform binaries on Linux)
+          npm install --force @rollup/rollup-linux-x64-gnu 2>/dev/null || true
 
       - name: Run tests
         run: npm test


### PR DESCRIPTION
## Summary

Fixes the GitHub Actions publish workflow failure caused by missing `@rollup/rollup-linux-x64-gnu` optional dependency on Linux runners.

## Problem

The workflow was failing at the test step with:
```
Error: Cannot find module @rollup/rollup-linux-x64-gnu
```

This is a known npm issue where `npm ci` doesn't properly install optional dependencies for platform-specific binaries.

## Solution

Added a step to force reinstall the Linux x64 rollup binary after `npm ci` runs. This ensures the platform-specific dependency is properly installed on the GitHub Actions Linux runner.

## Testing

- [x] Workflow syntax is valid
- [x] Tests pass locally
- [ ] Will verify workflow runs successfully after merge

## Related

Fixes the failure seen in https://github.com/nspady/google-calendar-mcp/actions/runs/18423803232

🤖 Generated with [Claude Code](https://claude.com/claude-code)