### PR TITLE
feat: auto-resolve calendar names and summaryOverride to IDs (closes #104)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,6 +194,10 @@ npm run dev test:integration:direct
 
 The codebase uses a structured response format for tool outputs. Recent commits (see git status) show migration to structured outputs using types from `src/types/structured-responses.ts`. When updating handlers, ensure responses conform to these structured formats.
 
+### MCP Structure
+
+MCP tools return errors as successful responses with error content, not as thrown exceptions. Integration tests must validate result.content[0].text for error messages, while unit tests of handlers directly can still catch thrown McpError exceptions before the MCP transport layer wraps them.
+
 ## Code Quality
 
 - **TypeScript**: Strict mode, avoid `any` types

--- a/src/handlers/core/BaseToolHandler.ts
+++ b/src/handlers/core/BaseToolHandler.ts
@@ -183,4 +183,209 @@ Original error: ${errorMessage}`
         }
     }
 
+    /**
+     * Resolves calendar name to calendar ID. If the input is already an ID, returns it unchanged.
+     * Supports both exact and case-insensitive name matching.
+     *
+     * Per Google Calendar API documentation:
+     * - Calendar IDs are typically email addresses (e.g., "user@gmail.com") or "primary" keyword
+     * - Calendar names are stored in "summary" field (calendar title) and "summaryOverride" field (user's personal override)
+     *
+     * Matching priority (user's personal override name takes precedence):
+     * 1. Exact match on summaryOverride
+     * 2. Case-insensitive match on summaryOverride
+     * 3. Exact match on summary
+     * 4. Case-insensitive match on summary
+     *
+     * This ensures if a user has set a personal override, it's always checked first (both exact and fuzzy),
+     * before falling back to the calendar's actual title.
+     *
+     * @param client OAuth2Client
+     * @param nameOrId Calendar name (summary/summaryOverride) or ID
+     * @returns Calendar ID
+     * @throws McpError if calendar name cannot be resolved
+     */
+    protected async resolveCalendarId(client: OAuth2Client, nameOrId: string): Promise<string> {
+        // If it looks like an ID (contains @ or is 'primary'), return as-is
+        if (nameOrId === 'primary' || nameOrId.includes('@')) {
+            return nameOrId;
+        }
+
+        // Try to resolve as a calendar name by fetching calendar list
+        try {
+            const calendar = this.getCalendar(client);
+            const response = await calendar.calendarList.list();
+            const calendars = response.data.items || [];
+
+            const lowerName = nameOrId.toLowerCase();
+
+            // Priority 1: Exact match on summaryOverride (user's personal name)
+            let match = calendars.find(cal => cal.summaryOverride === nameOrId);
+
+            // Priority 2: Case-insensitive match on summaryOverride
+            if (!match) {
+                match = calendars.find(cal =>
+                    cal.summaryOverride?.toLowerCase() === lowerName
+                );
+            }
+
+            // Priority 3: Exact match on summary (calendar's actual title)
+            if (!match) {
+                match = calendars.find(cal => cal.summary === nameOrId);
+            }
+
+            // Priority 4: Case-insensitive match on summary
+            if (!match) {
+                match = calendars.find(cal =>
+                    cal.summary?.toLowerCase() === lowerName
+                );
+            }
+
+            if (match && match.id) {
+                return match.id;
+            }
+
+            // Calendar name not found - provide helpful error message showing both summary and override
+            const availableCalendars = calendars
+                .map(cal => {
+                    if (cal.summaryOverride && cal.summaryOverride !== cal.summary) {
+                        return `"${cal.summaryOverride}" / "${cal.summary}" (${cal.id})`;
+                    }
+                    return `"${cal.summary}" (${cal.id})`;
+                })
+                .join(', ');
+
+            throw new McpError(
+                ErrorCode.InvalidRequest,
+                `Calendar "${nameOrId}" not found. Available calendars: ${availableCalendars || 'none'}. Use 'list-calendars' tool to see all available calendars.`
+            );
+        } catch (error) {
+            if (error instanceof McpError) {
+                throw error;
+            }
+            throw this.handleGoogleApiError(error);
+        }
+    }
+
+    /**
+     * Resolves multiple calendar names/IDs to calendar IDs in batch.
+     * Fetches calendar list once for efficiency when resolving multiple calendars.
+     * Optimized to skip API call if all inputs are already IDs.
+     *
+     * Matching priority (user's personal override name takes precedence):
+     * 1. Exact match on summaryOverride
+     * 2. Case-insensitive match on summaryOverride
+     * 3. Exact match on summary
+     * 4. Case-insensitive match on summary
+     *
+     * @param client OAuth2Client
+     * @param namesOrIds Array of calendar names (summary/summaryOverride) or IDs
+     * @returns Array of resolved calendar IDs
+     * @throws McpError if any calendar name cannot be resolved
+     */
+    protected async resolveCalendarIds(client: OAuth2Client, namesOrIds: string[]): Promise<string[]> {
+        // Filter out empty/whitespace-only strings
+        const validInputs = namesOrIds.filter(item => item && item.trim().length > 0);
+
+        if (validInputs.length === 0) {
+            throw new McpError(
+                ErrorCode.InvalidRequest,
+                'At least one valid calendar identifier is required'
+            );
+        }
+
+        // Quick check: if all inputs look like IDs, skip the API call
+        const needsResolution = validInputs.some(item =>
+            item !== 'primary' && !item.includes('@')
+        );
+
+        if (!needsResolution) {
+            // All inputs are already IDs, return as-is
+            return validInputs;
+        }
+
+        // Batch resolve all calendars at once by fetching calendar list once
+        const calendar = this.getCalendar(client);
+        const response = await calendar.calendarList.list();
+        const calendars = response.data.items || [];
+
+        // Build name-to-ID mappings for efficient lookup
+        // Priority: summaryOverride takes precedence over summary
+        const overrideToIdMap = new Map<string, string>();
+        const summaryToIdMap = new Map<string, string>();
+        const lowerOverrideToIdMap = new Map<string, string>();
+        const lowerSummaryToIdMap = new Map<string, string>();
+
+        for (const cal of calendars) {
+            if (cal.id) {
+                if (cal.summaryOverride) {
+                    overrideToIdMap.set(cal.summaryOverride, cal.id);
+                    lowerOverrideToIdMap.set(cal.summaryOverride.toLowerCase(), cal.id);
+                }
+                if (cal.summary) {
+                    summaryToIdMap.set(cal.summary, cal.id);
+                    lowerSummaryToIdMap.set(cal.summary.toLowerCase(), cal.id);
+                }
+            }
+        }
+
+        const resolvedIds: string[] = [];
+        const errors: string[] = [];
+
+        for (const nameOrId of validInputs) {
+            // If it looks like an ID (contains @ or is 'primary'), use as-is
+            if (nameOrId === 'primary' || nameOrId.includes('@')) {
+                resolvedIds.push(nameOrId);
+                continue;
+            }
+
+            const lowerName = nameOrId.toLowerCase();
+
+            // Priority 1: Exact match on summaryOverride
+            let id = overrideToIdMap.get(nameOrId);
+
+            // Priority 2: Case-insensitive match on summaryOverride
+            if (!id) {
+                id = lowerOverrideToIdMap.get(lowerName);
+            }
+
+            // Priority 3: Exact match on summary
+            if (!id) {
+                id = summaryToIdMap.get(nameOrId);
+            }
+
+            // Priority 4: Case-insensitive match on summary
+            if (!id) {
+                id = lowerSummaryToIdMap.get(lowerName);
+            }
+
+            if (id) {
+                resolvedIds.push(id);
+            } else {
+                errors.push(nameOrId);
+            }
+        }
+
+        // If any calendars couldn't be resolved, throw error with helpful message
+        if (errors.length > 0) {
+            const availableCalendars = calendars
+                .map(cal => {
+                    if (cal.summaryOverride && cal.summaryOverride !== cal.summary) {
+                        return `"${cal.summaryOverride}" / "${cal.summary}" (${cal.id})`;
+                    }
+                    return `"${cal.summary}" (${cal.id})`;
+                })
+                .join(', ');
+
+            const errorMessage = `Calendar(s) not found: ${errors.map(e => `"${e}"`).join(', ')}. Available calendars: ${availableCalendars || 'none'}. Use 'list-calendars' tool to see all available calendars.`;
+
+            throw new McpError(
+                ErrorCode.InvalidRequest,
+                errorMessage
+            );
+        }
+
+        return resolvedIds;
+    }
+
 }

--- a/src/tests/unit/handlers/BatchListEvents.test.ts
+++ b/src/tests/unit/handlers/BatchListEvents.test.ts
@@ -45,6 +45,17 @@ describe('Batch List Events Functionality', () => {
     mockCalendarApi = {
       events: {
         list: vi.fn()
+      },
+      calendarList: {
+        list: vi.fn().mockResolvedValue({
+          data: {
+            items: [
+              { id: 'primary', summary: 'Primary Calendar', summaryOverride: undefined },
+              { id: 'work@example.com', summary: 'Work Calendar', summaryOverride: undefined },
+              { id: 'personal@example.com', summary: 'Personal Calendar', summaryOverride: undefined }
+            ]
+          }
+        })
       }
     };
 

--- a/src/tests/unit/handlers/CalendarNameResolution.test.ts
+++ b/src/tests/unit/handlers/CalendarNameResolution.test.ts
@@ -1,0 +1,401 @@
+/**
+ * Unit tests for calendar name resolution feature
+ * Tests the resolveCalendarId and resolveCalendarIds methods in BaseToolHandler
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ListEventsHandler } from '../../../handlers/core/ListEventsHandler.js';
+import { OAuth2Client } from 'google-auth-library';
+import { google } from 'googleapis';
+
+// Mock googleapis globally
+vi.mock('googleapis', () => ({
+  google: {
+    calendar: vi.fn(() => ({
+      events: {
+        list: vi.fn()
+      },
+      calendarList: {
+        list: vi.fn(),
+        get: vi.fn()
+      }
+    }))
+  }
+}));
+
+describe('Calendar Name Resolution', () => {
+  const mockOAuth2Client = {
+    getAccessToken: vi.fn().mockResolvedValue({ token: 'mock-token' })
+  } as unknown as OAuth2Client;
+
+  let handler: ListEventsHandler;
+  let mockCalendar: any;
+
+  beforeEach(() => {
+    handler = new ListEventsHandler();
+    mockCalendar = {
+      events: {
+        list: vi.fn().mockResolvedValue({
+          data: {
+            items: []
+          }
+        })
+      },
+      calendarList: {
+        list: vi.fn().mockResolvedValue({
+          data: {
+            items: [
+              {
+                id: 'primary',
+                summary: 'Primary Calendar',
+                summaryOverride: undefined
+              },
+              {
+                id: 'work@example.com',
+                summary: 'Engineering Team - Project Alpha - Q4 2024',
+                summaryOverride: 'Work Calendar'
+              },
+              {
+                id: 'personal@example.com',
+                summary: 'Personal Calendar',
+                summaryOverride: undefined
+              },
+              {
+                id: 'team@example.com',
+                summary: 'Team Events',
+                summaryOverride: 'My Team'
+              }
+            ]
+          }
+        }),
+        get: vi.fn().mockResolvedValue({
+          data: { timeZone: 'UTC' }
+        })
+      }
+    };
+    vi.mocked(google.calendar).mockReturnValue(mockCalendar);
+  });
+
+  describe('summaryOverride matching priority', () => {
+    it('should match summaryOverride before summary (exact match)', async () => {
+      const args = {
+        calendarId: 'Work Calendar',
+        timeMin: '2025-06-02T00:00:00Z',
+        timeMax: '2025-06-09T23:59:59Z'
+      };
+
+      await handler.runTool(args, mockOAuth2Client);
+
+      // Should have called events.list with the resolved ID
+      expect(mockCalendar.events.list).toHaveBeenCalledWith(
+        expect.objectContaining({
+          calendarId: 'work@example.com'
+        })
+      );
+    });
+
+    it('should fall back to summary if summaryOverride does not match', async () => {
+      const args = {
+        calendarId: 'Personal Calendar',
+        timeMin: '2025-06-02T00:00:00Z',
+        timeMax: '2025-06-09T23:59:59Z'
+      };
+
+      await handler.runTool(args, mockOAuth2Client);
+
+      expect(mockCalendar.events.list).toHaveBeenCalledWith(
+        expect.objectContaining({
+          calendarId: 'personal@example.com'
+        })
+      );
+    });
+
+    it('should match summaryOverride case-insensitively', async () => {
+      const args = {
+        calendarId: 'WORK CALENDAR',
+        timeMin: '2025-06-02T00:00:00Z',
+        timeMax: '2025-06-09T23:59:59Z'
+      };
+
+      await handler.runTool(args, mockOAuth2Client);
+
+      expect(mockCalendar.events.list).toHaveBeenCalledWith(
+        expect.objectContaining({
+          calendarId: 'work@example.com'
+        })
+      );
+    });
+
+    it('should match summary case-insensitively', async () => {
+      const args = {
+        calendarId: 'personal calendar',
+        timeMin: '2025-06-02T00:00:00Z',
+        timeMax: '2025-06-09T23:59:59Z'
+      };
+
+      await handler.runTool(args, mockOAuth2Client);
+
+      expect(mockCalendar.events.list).toHaveBeenCalledWith(
+        expect.objectContaining({
+          calendarId: 'personal@example.com'
+        })
+      );
+    });
+
+    it('should prefer summaryOverride over similar summary name', async () => {
+      // Even if there's a calendar with summary "My Team",
+      // it should match the summaryOverride first
+      const args = {
+        calendarId: 'My Team',
+        timeMin: '2025-06-02T00:00:00Z',
+        timeMax: '2025-06-09T23:59:59Z'
+      };
+
+      await handler.runTool(args, mockOAuth2Client);
+
+      expect(mockCalendar.events.list).toHaveBeenCalledWith(
+        expect.objectContaining({
+          calendarId: 'team@example.com'
+        })
+      );
+    });
+  });
+
+  describe('multiple calendar name resolution', () => {
+    it('should resolve multiple calendar names including summaryOverride', async () => {
+      const args = {
+        calendarId: ['Work Calendar', 'Personal Calendar'],  // Pass as array, not JSON string
+        timeMin: '2025-06-02T00:00:00Z',
+        timeMax: '2025-06-09T23:59:59Z'
+      };
+
+      // Mock fetch for batch requests
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: {
+          get: vi.fn()
+        },
+        text: () => Promise.resolve(`--batch_boundary
+Content-Type: application/http
+Content-ID: <item1>
+
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{"items": []}
+
+--batch_boundary
+Content-Type: application/http
+Content-ID: <item2>
+
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{"items": []}
+
+--batch_boundary--`)
+      });
+
+      await handler.runTool(args, mockOAuth2Client);
+
+      // Should have called fetch with both resolved calendar IDs
+      expect(global.fetch).toHaveBeenCalled();
+      const fetchCall = vi.mocked(global.fetch).mock.calls[0];
+      const requestBody = fetchCall[1]?.body as string;
+
+      // Calendar IDs may be URL-encoded in batch request
+      expect(requestBody).toMatch(/work@example\.com|work%40example\.com/);
+      expect(requestBody).toMatch(/personal@example\.com|personal%40example\.com/);
+    });
+
+    it('should resolve mix of IDs, summary names, and summaryOverride names', async () => {
+      const args = {
+        calendarId: ['primary', 'Work Calendar', 'Personal Calendar'],  // Pass as array
+        timeMin: '2025-06-02T00:00:00Z',
+        timeMax: '2025-06-09T23:59:59Z'
+      };
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: {
+          get: vi.fn()
+        },
+        text: () => Promise.resolve(`--batch_boundary
+Content-Type: application/http
+
+HTTP/1.1 200 OK
+
+{"items": []}
+--batch_boundary--`)
+      });
+
+      await handler.runTool(args, mockOAuth2Client);
+
+      const fetchCall = vi.mocked(global.fetch).mock.calls[0];
+      const requestBody = fetchCall[1]?.body as string;
+
+      // Should include all three calendar IDs (may be URL-encoded)
+      expect(requestBody).toContain('primary');
+      expect(requestBody).toMatch(/work@example\.com|work%40example\.com/);
+      expect(requestBody).toMatch(/personal@example\.com|personal%40example\.com/);
+    });
+  });
+
+  describe('error handling with summaryOverride', () => {
+    it('should provide helpful error listing both summaryOverride and summary', async () => {
+      const args = {
+        calendarId: 'NonExistentCalendar',
+        timeMin: '2025-06-02T00:00:00Z',
+        timeMax: '2025-06-09T23:59:59Z'
+      };
+
+      await expect(handler.runTool(args, mockOAuth2Client)).rejects.toThrow(
+        /Calendar\(s\) not found: "NonExistentCalendar"/
+      );
+
+      try {
+        await handler.runTool(args, mockOAuth2Client);
+      } catch (error: any) {
+        // Error message should show both override and original name
+        expect(error.message).toContain('Work Calendar');
+        expect(error.message).toContain('Engineering Team - Project Alpha - Q4 2024');
+        expect(error.message).toContain('My Team');
+        expect(error.message).toContain('Team Events');
+      }
+    });
+
+    it('should handle calendar with summaryOverride same as summary', async () => {
+      // Update mock to have a calendar where override equals summary
+      mockCalendar.calendarList.list.mockResolvedValueOnce({
+        data: {
+          items: [
+            {
+              id: 'test@example.com',
+              summary: 'Test Calendar',
+              summaryOverride: 'Test Calendar'
+            }
+          ]
+        }
+      });
+
+      const args = {
+        calendarId: 'NonExistent',
+        timeMin: '2025-06-02T00:00:00Z',
+        timeMax: '2025-06-09T23:59:59Z'
+      };
+
+      try {
+        await handler.runTool(args, mockOAuth2Client);
+      } catch (error: any) {
+        // Should not show duplicate when override equals summary
+        const message = error.message;
+        const matches = (message.match(/Test Calendar/g) || []).length;
+        expect(matches).toBe(1);
+      }
+    });
+  });
+
+  describe('performance optimization', () => {
+    it('should skip API call when all inputs are IDs', async () => {
+      const args = {
+        calendarId: ['primary', 'work@example.com'],  // Pass as array
+        timeMin: '2025-06-02T00:00:00Z',
+        timeMax: '2025-06-09T23:59:59Z'
+      };
+
+      // Reset the mock to track calls
+      mockCalendar.calendarList.list.mockClear();
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: {
+          get: vi.fn()
+        },
+        text: () => Promise.resolve(`--batch_boundary
+Content-Type: application/http
+
+HTTP/1.1 200 OK
+
+{"items": []}
+--batch_boundary--`)
+      });
+
+      await handler.runTool(args, mockOAuth2Client);
+
+      // Should NOT have called calendarList.list since all inputs are IDs
+      expect(mockCalendar.calendarList.list).not.toHaveBeenCalled();
+    });
+
+    it('should call API only once for multiple name resolutions', async () => {
+      const args = {
+        calendarId: ['Work Calendar', 'Personal Calendar', 'My Team'],  // Pass as array
+        timeMin: '2025-06-02T00:00:00Z',
+        timeMax: '2025-06-09T23:59:59Z'
+      };
+
+      mockCalendar.calendarList.list.mockClear();
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: {
+          get: vi.fn()
+        },
+        text: () => Promise.resolve(`--batch_boundary
+Content-Type: application/http
+
+HTTP/1.1 200 OK
+
+{"items": []}
+--batch_boundary--`)
+      });
+
+      await handler.runTool(args, mockOAuth2Client);
+
+      // Should have called calendarList.list exactly once
+      expect(mockCalendar.calendarList.list).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('input validation', () => {
+    it('should filter out empty strings', async () => {
+      const args = {
+        calendarId: ['primary', '', 'Work Calendar'],  // Pass as array
+        timeMin: '2025-06-02T00:00:00Z',
+        timeMax: '2025-06-09T23:59:59Z'
+      };
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: {
+          get: vi.fn()
+        },
+        text: () => Promise.resolve(`--batch_boundary
+Content-Type: application/http
+
+HTTP/1.1 200 OK
+
+{"items": []}
+--batch_boundary--`)
+      });
+
+      // Should not throw - empty string should be filtered out
+      await expect(handler.runTool(args, mockOAuth2Client)).resolves.toBeDefined();
+    });
+
+    it('should reject when all inputs are empty/whitespace', async () => {
+      const args = {
+        calendarId: ['', '  ', '\t'],  // Pass as array
+        timeMin: '2025-06-02T00:00:00Z',
+        timeMax: '2025-06-09T23:59:59Z'
+      };
+
+      await expect(handler.runTool(args, mockOAuth2Client)).rejects.toThrow(
+        /At least one valid calendar identifier is required/
+      );
+    });
+  });
+});

--- a/src/tests/unit/handlers/ListEventsHandler.test.ts
+++ b/src/tests/unit/handlers/ListEventsHandler.test.ts
@@ -45,6 +45,15 @@ describe('ListEventsHandler JSON String Handling', () => {
       calendarList: {
         get: vi.fn().mockResolvedValue({
           data: { timeZone: 'UTC' }
+        }),
+        list: vi.fn().mockResolvedValue({
+          data: {
+            items: [
+              { id: 'primary', summary: 'Primary Calendar' },
+              { id: 'work@example.com', summary: 'Work Calendar' },
+              { id: 'personal@example.com', summary: 'Personal Calendar' }
+            ]
+          }
         })
       }
     };
@@ -135,7 +144,15 @@ describe('ListEventsHandler - Timezone Handling', () => {
         list: vi.fn()
       },
       calendarList: {
-        get: vi.fn()
+        get: vi.fn(),
+        list: vi.fn().mockResolvedValue({
+          data: {
+            items: [
+              { id: 'primary', summary: 'Primary Calendar' },
+              { id: 'work@example.com', summary: 'Work Calendar' }
+            ]
+          }
+        })
       }
     };
     vi.mocked(google.calendar).mockReturnValue(mockCalendar);

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -487,14 +487,14 @@ export class ToolRegistry {
     },
     {
       name: "list-events",
-      description: "List events from one or more calendars.",
+      description: "List events from one or more calendars. Supports both calendar IDs and calendar names.",
       schema: ToolSchemas['list-events'],
       handler: ListEventsHandler,
       // Custom schema for MCP registration (string-only for OpenAI compatibility)
       // Note: Runtime validation accepts native arrays too, but schema advertises string for broader client compatibility
       customInputSchema: {
         calendarId: z.string().describe(
-          "Calendar ID(s) to query. Single ID: 'primary'. Multiple IDs: JSON array string '[\"cal1\", \"cal2\"]' (single or double quotes supported)"
+          "Calendar identifier(s) to query. Accepts calendar IDs (e.g., 'primary', 'user@gmail.com') OR calendar names (e.g., 'Work', 'Personal'). Names match against both the calendar's title and user's personal override name. Single calendar: 'primary' or 'Work'. Multiple calendars: JSON array string '[\"Work\", \"Personal\"]'"
         ),
         timeMin: timeMinSchema,
         timeMax: timeMaxSchema,


### PR DESCRIPTION
## Summary

Adds automatic calendar name resolution to the `list-events` tool, allowing users to reference calendars by their display names instead of IDs. This eliminates the need for users to manually look up calendar IDs.

## Key Changes

- **Automatic name resolution**: `list-events` now accepts calendar names (summary or summaryOverride) in addition to IDs
- **Smart priority matching**: Prefers user's personal override names (summaryOverride) over default calendar titles (summary)
- **Batch optimization**: Single API call resolves multiple calendar names efficiently
- **Helpful errors**: Clear messages showing available calendars when names don't match

## Examples

```typescript
// Before: Had to use calendar IDs
calendarId: "user@example.com"

// After: Can use calendar names
calendarId: "Work Calendar"

// Multiple calendars work too
calendarId: ["Work Calendar", "Personal", "primary"]
```

## Matching Priority

1. Exact match on summaryOverride (user's custom name)
2. Case-insensitive match on summaryOverride  
3. Exact match on summary (calendar's default title)
4. Case-insensitive match on summary

This ensures user customizations are always respected.