### PR TITLE
fix(auth): update error log related to auth server port for more clarity

### DIFF
--- a/src/auth-server.ts
+++ b/src/auth-server.ts
@@ -11,7 +11,7 @@ async function runAuthServer() {
     const success = await authServer.start(true);
     
     if (!success && !authServer.authCompletedSuccessfully) {
-      process.stderr.write('Authentication failed. Could not start server or validate existing tokens. Check port availability (3000-3004) and try again.\n');
+      process.stderr.write('Authentication failed. Could not start server or validate existing tokens.\n');
       process.exit(1);
     } else if (authServer.authCompletedSuccessfully) {
       process.stderr.write('Authentication successful.\n');

--- a/src/auth/server.ts
+++ b/src/auth/server.ts
@@ -167,6 +167,8 @@ export class AuthServer {
     // Try to start the server and get the port
     const port = await this.startServerOnAvailablePort();
     if (port === null) {
+      process.stderr.write(`Could not start auth server on available port. Please check port availability (${this.portRange.start}-${this.portRange.end}) and try again.\n`);
+
       this.authCompletedSuccessfully = false;
       return false;
     }


### PR DESCRIPTION
## Description

Fixes incorrect port range in error messages and improves error logging clarity in the authentication flow.

## Changes

**Modified Files:**
- `src/auth/server.ts` - Added specific port availability error message when `startServerOnAvailablePort()` fails, using correct port range (3500-3505)
- `src/auth-server.ts` - Removed incorrect port range (3000-3004) from top-level error message

**What Was Wrong:**
The existing error message incorrectly stated ports 3000-3004, when the actual auth server port range is 3500-3505.

**Error Message Flow:**
1. Port check fails → logs "Could not start auth server on available port. Please check port availability (3500-3505)..."
2. Top-level auth failure → logs generic "Authentication failed. Could not start server or validate existing tokens."

## Testing

- ✅ Built successfully with `npm run build`
- ✅ Auth flow tested with `npm run auth`