### PR TITLE
feat: add respond-to-event tool with comment and recurring event support

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,22 @@ Along with the normal capabilities you would expect for a calendar integration y
    ```
    Which events tomorrow have attendees who have not accepted the invitation?
    ```
-5. Auto coordinate events:
+5. Respond to invitations:
+   ```
+   Accept the team meeting invitation on my calendar for tomorrow at 2pm
+   ```
+   Decline with a note:
+   ```
+   Decline the Friday meeting with a note that I have a scheduling conflict
+   ```
+   Respond to recurring events:
+   ```
+   Accept just this week's standup, but keep future instances as tentative
+   ```
+   ```
+   Decline all future Monday planning meetings
+   ```
+6. Auto coordinate events:
    ```
    Here's some available that was provided to me by someone. {available times}
    Take a look at the times provided and let me know which ones are open on my calendar.
@@ -152,6 +167,7 @@ Along with the normal capabilities you would expect for a calendar integration y
 | `create-event` | Create new calendar events |
 | `update-event` | Update existing events |
 | `delete-event` | Delete events |
+| `respond-to-event` | Respond to event invitations (Accept, Decline, Maybe, No Response) |
 | `get-freebusy` | Check availability across calendars, including external calendars |
 | `list-colors` | List available event colors |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -718,7 +718,6 @@
       "version": "0.2.5",
       "dev": true,
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=0.2.0"
       }
@@ -938,6 +937,7 @@
     "node_modules/express": {
       "version": "5.1.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.0",
@@ -1629,7 +1629,6 @@
       "dev": true,
       "license": "MIT/X11",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -1858,6 +1857,7 @@
       "version": "4.0.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2302,23 +2302,6 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
-    "node_modules/stylus": {
-      "version": "0.26.1",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "cssom": "0.2.x",
-        "debug": "*",
-        "mkdirp": "0.3.x"
-      },
-      "bin": {
-        "stylus": "bin/stylus"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "dev": true,
@@ -2472,6 +2455,7 @@
       "version": "6.3.5",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -2566,6 +2550,7 @@
       "version": "3.2.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.3",
@@ -2769,44 +2754,10 @@
       "version": "1.0.2",
       "license": "ISC"
     },
-    "node_modules/ws": {
-      "version": "8.18.3",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/yaml": {
-      "version": "2.8.1",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      }
-    },
     "node_modules/zod": {
       "version": "3.25.67",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/handlers/core/RespondToEventHandler.ts
+++ b/src/handlers/core/RespondToEventHandler.ts
@@ -1,0 +1,133 @@
+import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { OAuth2Client } from "google-auth-library";
+import { BaseToolHandler } from "./BaseToolHandler.js";
+import { calendar_v3 } from 'googleapis';
+import { createStructuredResponse } from "../../utils/response-builder.js";
+import { RespondToEventResponse, convertGoogleEventToStructured } from "../../types/structured-responses.js";
+import { RecurringEventHelpers, RecurringEventError, RECURRING_EVENT_ERRORS } from './RecurringEventHelpers.js';
+
+export type RespondToEventInput = {
+    calendarId: string;
+    eventId: string;
+    response: "accepted" | "declined" | "tentative" | "needsAction";
+    comment?: string;
+    modificationScope?: "thisEventOnly" | "all";
+    originalStartTime?: string;
+    sendUpdates?: "all" | "externalOnly" | "none";
+};
+
+export class RespondToEventHandler extends BaseToolHandler {
+    async runTool(args: any, oauth2Client: OAuth2Client): Promise<CallToolResult> {
+        const validArgs = args as RespondToEventInput;
+
+        try {
+            const calendar = this.getCalendar(oauth2Client);
+            const helpers = new RecurringEventHelpers(calendar);
+
+            // 1. Determine the target event ID (may be instance-specific for recurring events)
+            let targetEventId = validArgs.eventId;
+
+            // Handle recurring event scopes
+            if (validArgs.modificationScope === 'thisEventOnly') {
+                if (!validArgs.originalStartTime) {
+                    throw new RecurringEventError(
+                        'originalStartTime is required when modificationScope is "thisEventOnly"',
+                        RECURRING_EVENT_ERRORS.MISSING_ORIGINAL_TIME
+                    );
+                }
+
+                // Detect if event is recurring
+                const eventType = await helpers.detectEventType(validArgs.eventId, validArgs.calendarId);
+                if (eventType !== 'recurring') {
+                    throw new RecurringEventError(
+                        'modificationScope "thisEventOnly" can only be used with recurring events',
+                        RECURRING_EVENT_ERRORS.NON_RECURRING_SCOPE
+                    );
+                }
+
+                // Format instance ID for single instance response
+                targetEventId = helpers.formatInstanceId(validArgs.eventId, validArgs.originalStartTime);
+            } else if (validArgs.modificationScope === 'all') {
+                // Use base event ID (current behavior)
+                targetEventId = validArgs.eventId;
+            }
+            // If no scope specified, default to 'all' behavior (use base event ID)
+
+            // 2. Get the event to find the current user's attendee entry
+            const eventResponse = await calendar.events.get({
+                calendarId: validArgs.calendarId,
+                eventId: targetEventId
+            });
+
+            const event = eventResponse.data;
+            if (!event) {
+                throw new Error('Event not found');
+            }
+
+            // 3. Find the authenticated user's attendee entry (marked with self: true)
+            const attendees = event.attendees || [];
+            const selfAttendeeIndex = attendees.findIndex(a => a.self === true);
+
+            if (selfAttendeeIndex === -1) {
+                throw new Error(
+                    'You are not an attendee of this event. Only attendees can respond to event invitations.'
+                );
+            }
+
+            const selfAttendee = attendees[selfAttendeeIndex];
+
+            // 4. Check if user is the organizer (organizers don't respond to their own events)
+            if (selfAttendee.organizer === true) {
+                throw new Error(
+                    'You are the organizer of this event. Organizers do not respond to their own event invitations.'
+                );
+            }
+
+            // 5. Update the response status and optionally comment for the authenticated user
+            const updatedAttendees = [...attendees];
+            updatedAttendees[selfAttendeeIndex] = {
+                ...selfAttendee,
+                responseStatus: validArgs.response,
+                ...(validArgs.comment !== undefined && { comment: validArgs.comment })
+            };
+
+            // 6. Patch the event with the updated attendee list
+            const updateResponse = await calendar.events.patch({
+                calendarId: validArgs.calendarId,
+                eventId: targetEventId,
+                requestBody: {
+                    attendees: updatedAttendees
+                },
+                sendUpdates: validArgs.sendUpdates || "all"
+            });
+
+            if (!updateResponse.data) {
+                throw new Error('Failed to update event response');
+            }
+
+            // 7. Create structured response
+            let message = `Your response has been set to "${validArgs.response}"`;
+            if (validArgs.modificationScope === 'thisEventOnly') {
+                message += ' for this instance only';
+            } else if (validArgs.modificationScope === 'all') {
+                message += ' for all instances';
+            }
+            if (validArgs.comment) {
+                message += ` with note: "${validArgs.comment}"`;
+            }
+
+            const response: RespondToEventResponse = {
+                event: convertGoogleEventToStructured(updateResponse.data, validArgs.calendarId),
+                responseStatus: validArgs.response,
+                message: message
+            };
+
+            return createStructuredResponse(response);
+        } catch (error: any) {
+            if (error instanceof RecurringEventError) {
+                throw error;
+            }
+            throw this.handleGoogleApiError(error);
+        }
+    }
+}

--- a/src/tests/integration/direct-integration.test.ts
+++ b/src/tests/integration/direct-integration.test.ts
@@ -2486,6 +2486,199 @@ describe('Google Calendar MCP - Direct Integration Tests', () => {
     });
   });
 
+  describe('Event Response Management', () => {
+    it('should respond to event invitations', async () => {
+      // Note: This test requires creating an event where the authenticated user
+      // is invited as an attendee (not the organizer)
+      // For this test to work properly, we need the test account's email
+
+      // Create an event with the test user as an attendee
+      const testUserEmail = process.env.TEST_USER_EMAIL || 'test@example.com';
+      const eventData = TestDataFactory.createSingleEvent({
+        summary: `Integration Test - RSVP Test ${Date.now()}`,
+        attendees: [
+          { email: testUserEmail }
+        ]
+      });
+
+      const eventId = await createTestEvent(eventData);
+      createdEventIds.push(eventId);
+
+      // Wait for event to be created
+      await new Promise(resolve => setTimeout(resolve, 2000));
+
+      // Respond to the event with "accepted"
+      const respondStartTime = testFactory.startTimer('respond-to-event');
+
+      try {
+        const respondResult = await client.callTool({
+          name: 'respond-to-event',
+          arguments: {
+            calendarId: TEST_CALENDAR_ID,
+            eventId: eventId,
+            response: 'accepted',
+            sendUpdates: SEND_UPDATES
+          }
+        });
+
+        testFactory.endTimer('respond-to-event', respondStartTime, true);
+
+        expect(TestDataFactory.validateEventResponse(respondResult)).toBe(true);
+
+        const responseText = (respondResult.content as any)[0].text;
+        const response = JSON.parse(responseText);
+
+        expect(response.responseStatus).toBe('accepted');
+        expect(response.message).toContain('accepted');
+        expect(response.event).toBeDefined();
+        expect(response.event.id).toBe(eventId);
+
+        console.log('✅ Successfully responded to event invitation');
+
+        // Try other response types
+        const declineResult = await client.callTool({
+          name: 'respond-to-event',
+          arguments: {
+            calendarId: TEST_CALENDAR_ID,
+            eventId: eventId,
+            response: 'declined',
+            sendUpdates: SEND_UPDATES
+          }
+        });
+
+        const declineResponse = JSON.parse((declineResult.content as any)[0].text);
+        expect(declineResponse.responseStatus).toBe('declined');
+
+        console.log('✅ Successfully changed response to declined');
+
+        // Try tentative
+        const tentativeResult = await client.callTool({
+          name: 'respond-to-event',
+          arguments: {
+            calendarId: TEST_CALENDAR_ID,
+            eventId: eventId,
+            response: 'tentative',
+            sendUpdates: SEND_UPDATES
+          }
+        });
+
+        const tentativeResponse = JSON.parse((tentativeResult.content as any)[0].text);
+        expect(tentativeResponse.responseStatus).toBe('tentative');
+
+        console.log('✅ Successfully changed response to tentative');
+      } catch (error) {
+        testFactory.endTimer('respond-to-event', respondStartTime, false, String(error));
+        // If the error is about not being an attendee, that's expected if TEST_USER_EMAIL
+        // doesn't match the authenticated account
+        if (String(error).includes('not an attendee')) {
+          console.log('⚠️  Skipping respond-to-event test - authenticated user not an attendee');
+          console.log('   Set TEST_USER_EMAIL to the authenticated account\'s email to run this test');
+        } else {
+          throw error;
+        }
+      }
+    });
+
+    it('should respond with a comment/note', async () => {
+      const testUserEmail = process.env.TEST_USER_EMAIL || 'test@example.com';
+      const eventData = TestDataFactory.createSingleEvent({
+        summary: `Integration Test - Response with Comment ${Date.now()}`,
+        attendees: [
+          { email: testUserEmail }
+        ]
+      });
+
+      const eventId = await createTestEvent(eventData);
+      createdEventIds.push(eventId);
+
+      await new Promise(resolve => setTimeout(resolve, 2000));
+
+      try {
+        // Decline with a comment
+        const declineResult = await client.callTool({
+          name: 'respond-to-event',
+          arguments: {
+            calendarId: TEST_CALENDAR_ID,
+            eventId: eventId,
+            response: 'declined',
+            comment: 'I have a scheduling conflict',
+            sendUpdates: SEND_UPDATES
+          }
+        });
+
+        const declineResponse = JSON.parse((declineResult.content as any)[0].text);
+        expect(declineResponse.responseStatus).toBe('declined');
+        expect(declineResponse.message).toContain('I have a scheduling conflict');
+
+        console.log('✅ Successfully declined with comment');
+      } catch (error) {
+        if (String(error).includes('not an attendee')) {
+          console.log('⚠️  Skipping comment test - authenticated user not an attendee');
+        } else {
+          throw error;
+        }
+      }
+    });
+
+    it('should respond to single instance of recurring event', async () => {
+      const testUserEmail = process.env.TEST_USER_EMAIL || 'test@example.com';
+
+      // Create a recurring event
+      const recurringEventData = TestDataFactory.createRecurringEvent({
+        summary: `Integration Test - Recurring RSVP ${Date.now()}`,
+        attendees: [
+          { email: testUserEmail }
+        ]
+      });
+
+      const eventId = await createTestEvent(recurringEventData);
+      createdEventIds.push(eventId);
+
+      await new Promise(resolve => setTimeout(resolve, 2000));
+
+      try {
+        // Get the event to find the first instance start time
+        const getResult = await client.callTool({
+          name: 'get-event',
+          arguments: {
+            calendarId: TEST_CALENDAR_ID,
+            eventId: eventId
+          }
+        });
+
+        const eventInfo = JSON.parse((getResult.content as any)[0].text);
+        const originalStartTime = eventInfo.event.start.dateTime || eventInfo.event.start.date;
+
+        // Decline just this instance
+        const respondResult = await client.callTool({
+          name: 'respond-to-event',
+          arguments: {
+            calendarId: TEST_CALENDAR_ID,
+            eventId: eventId,
+            response: 'declined',
+            modificationScope: 'thisEventOnly',
+            originalStartTime: originalStartTime,
+            comment: 'Cannot make this one',
+            sendUpdates: SEND_UPDATES
+          }
+        });
+
+        const response = JSON.parse((respondResult.content as any)[0].text);
+        expect(response.responseStatus).toBe('declined');
+        expect(response.message).toContain('this instance only');
+        expect(response.message).toContain('Cannot make this one');
+
+        console.log('✅ Successfully declined single instance of recurring event');
+      } catch (error) {
+        if (String(error).includes('not an attendee')) {
+          console.log('⚠️  Skipping recurring event test - authenticated user not an attendee');
+        } else {
+          throw error;
+        }
+      }
+    });
+  });
+
   describe('Performance Benchmarks', () => {
     it('should complete basic operations within reasonable time limits', async () => {
       // Create a test event for performance testing

--- a/src/tests/unit/handlers/RespondToEventHandler.test.ts
+++ b/src/tests/unit/handlers/RespondToEventHandler.test.ts
@@ -1,0 +1,634 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { RespondToEventHandler } from '../../../handlers/core/RespondToEventHandler.js';
+import { OAuth2Client } from 'google-auth-library';
+
+// Mock the googleapis module
+vi.mock('googleapis', () => ({
+  google: {
+    calendar: vi.fn(() => ({
+      events: {
+        get: vi.fn(),
+        patch: vi.fn()
+      }
+    }))
+  },
+  calendar_v3: {}
+}));
+
+describe('RespondToEventHandler', () => {
+  let handler: RespondToEventHandler;
+  let mockOAuth2Client: OAuth2Client;
+  let mockCalendar: any;
+
+  beforeEach(() => {
+    handler = new RespondToEventHandler();
+    mockOAuth2Client = new OAuth2Client();
+
+    // Setup mock calendar
+    mockCalendar = {
+      events: {
+        get: vi.fn(),
+        patch: vi.fn()
+      }
+    };
+
+    // Mock the getCalendar method
+    vi.spyOn(handler as any, 'getCalendar').mockReturnValue(mockCalendar);
+  });
+
+  describe('runTool', () => {
+    it('should successfully accept an event invitation', async () => {
+      const mockEvent = {
+        id: 'event123',
+        summary: 'Team Meeting',
+        start: { dateTime: '2025-01-15T10:00:00Z' },
+        end: { dateTime: '2025-01-15T11:00:00Z' },
+        attendees: [
+          { email: 'organizer@example.com', organizer: true, responseStatus: 'accepted' },
+          { email: 'self@example.com', self: true, responseStatus: 'needsAction' }
+        ]
+      };
+
+      const updatedEvent = {
+        ...mockEvent,
+        attendees: [
+          { email: 'organizer@example.com', organizer: true, responseStatus: 'accepted' },
+          { email: 'self@example.com', self: true, responseStatus: 'accepted' }
+        ]
+      };
+
+      mockCalendar.events.get.mockResolvedValue({ data: mockEvent });
+      mockCalendar.events.patch.mockResolvedValue({ data: updatedEvent });
+
+      const args = {
+        calendarId: 'primary',
+        eventId: 'event123',
+        response: 'accepted' as const
+      };
+
+      const result = await handler.runTool(args, mockOAuth2Client);
+
+      expect(mockCalendar.events.get).toHaveBeenCalledWith({
+        calendarId: 'primary',
+        eventId: 'event123'
+      });
+
+      expect(mockCalendar.events.patch).toHaveBeenCalledWith({
+        calendarId: 'primary',
+        eventId: 'event123',
+        requestBody: {
+          attendees: [
+            { email: 'organizer@example.com', organizer: true, responseStatus: 'accepted' },
+            { email: 'self@example.com', self: true, responseStatus: 'accepted' }
+          ]
+        },
+        sendUpdates: 'all'
+      });
+
+      expect(result.content[0].type).toBe('text');
+      const response = JSON.parse(result.content[0].text);
+      expect(response.responseStatus).toBe('accepted');
+      expect(response.message).toBe('Your response has been set to "accepted"');
+      expect(response.event).toBeDefined();
+    });
+
+    it('should successfully decline an event invitation', async () => {
+      const mockEvent = {
+        id: 'event123',
+        summary: 'Team Meeting',
+        start: { dateTime: '2025-01-15T10:00:00Z' },
+        end: { dateTime: '2025-01-15T11:00:00Z' },
+        attendees: [
+          { email: 'organizer@example.com', organizer: true, responseStatus: 'accepted' },
+          { email: 'self@example.com', self: true, responseStatus: 'needsAction' }
+        ]
+      };
+
+      const updatedEvent = {
+        ...mockEvent,
+        attendees: [
+          { email: 'organizer@example.com', organizer: true, responseStatus: 'accepted' },
+          { email: 'self@example.com', self: true, responseStatus: 'declined' }
+        ]
+      };
+
+      mockCalendar.events.get.mockResolvedValue({ data: mockEvent });
+      mockCalendar.events.patch.mockResolvedValue({ data: updatedEvent });
+
+      const args = {
+        calendarId: 'primary',
+        eventId: 'event123',
+        response: 'declined' as const
+      };
+
+      const result = await handler.runTool(args, mockOAuth2Client);
+
+      expect(mockCalendar.events.patch).toHaveBeenCalledWith({
+        calendarId: 'primary',
+        eventId: 'event123',
+        requestBody: {
+          attendees: expect.arrayContaining([
+            expect.objectContaining({ responseStatus: 'declined', self: true })
+          ])
+        },
+        sendUpdates: 'all'
+      });
+
+      const response = JSON.parse(result.content[0].text);
+      expect(response.responseStatus).toBe('declined');
+    });
+
+    it('should successfully respond with tentative (maybe)', async () => {
+      const mockEvent = {
+        id: 'event123',
+        summary: 'Team Meeting',
+        start: { dateTime: '2025-01-15T10:00:00Z' },
+        end: { dateTime: '2025-01-15T11:00:00Z' },
+        attendees: [
+          { email: 'organizer@example.com', organizer: true, responseStatus: 'accepted' },
+          { email: 'self@example.com', self: true, responseStatus: 'needsAction' }
+        ]
+      };
+
+      const updatedEvent = {
+        ...mockEvent,
+        attendees: [
+          { email: 'organizer@example.com', organizer: true, responseStatus: 'accepted' },
+          { email: 'self@example.com', self: true, responseStatus: 'tentative' }
+        ]
+      };
+
+      mockCalendar.events.get.mockResolvedValue({ data: mockEvent });
+      mockCalendar.events.patch.mockResolvedValue({ data: updatedEvent });
+
+      const args = {
+        calendarId: 'primary',
+        eventId: 'event123',
+        response: 'tentative' as const
+      };
+
+      const result = await handler.runTool(args, mockOAuth2Client);
+
+      const response = JSON.parse(result.content[0].text);
+      expect(response.responseStatus).toBe('tentative');
+      expect(response.message).toBe('Your response has been set to "tentative"');
+    });
+
+    it('should respect custom sendUpdates parameter', async () => {
+      const mockEvent = {
+        id: 'event123',
+        summary: 'Team Meeting',
+        start: { dateTime: '2025-01-15T10:00:00Z' },
+        end: { dateTime: '2025-01-15T11:00:00Z' },
+        attendees: [
+          { email: 'organizer@example.com', organizer: true, responseStatus: 'accepted' },
+          { email: 'self@example.com', self: true, responseStatus: 'needsAction' }
+        ]
+      };
+
+      mockCalendar.events.get.mockResolvedValue({ data: mockEvent });
+      mockCalendar.events.patch.mockResolvedValue({ data: mockEvent });
+
+      const args = {
+        calendarId: 'primary',
+        eventId: 'event123',
+        response: 'accepted' as const,
+        sendUpdates: 'none' as const
+      };
+
+      await handler.runTool(args, mockOAuth2Client);
+
+      expect(mockCalendar.events.patch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sendUpdates: 'none'
+        })
+      );
+    });
+
+    it('should throw error when user is not an attendee', async () => {
+      const mockEvent = {
+        id: 'event123',
+        summary: 'Team Meeting',
+        start: { dateTime: '2025-01-15T10:00:00Z' },
+        end: { dateTime: '2025-01-15T11:00:00Z' },
+        attendees: [
+          { email: 'organizer@example.com', organizer: true, responseStatus: 'accepted' },
+          { email: 'other@example.com', responseStatus: 'accepted' }
+        ]
+      };
+
+      mockCalendar.events.get.mockResolvedValue({ data: mockEvent });
+
+      const args = {
+        calendarId: 'primary',
+        eventId: 'event123',
+        response: 'accepted' as const
+      };
+
+      await expect(handler.runTool(args, mockOAuth2Client)).rejects.toThrow(
+        'You are not an attendee of this event. Only attendees can respond to event invitations.'
+      );
+    });
+
+    it('should throw error when user is the organizer', async () => {
+      const mockEvent = {
+        id: 'event123',
+        summary: 'Team Meeting',
+        start: { dateTime: '2025-01-15T10:00:00Z' },
+        end: { dateTime: '2025-01-15T11:00:00Z' },
+        attendees: [
+          { email: 'self@example.com', self: true, organizer: true, responseStatus: 'accepted' },
+          { email: 'other@example.com', responseStatus: 'needsAction' }
+        ]
+      };
+
+      mockCalendar.events.get.mockResolvedValue({ data: mockEvent });
+
+      const args = {
+        calendarId: 'primary',
+        eventId: 'event123',
+        response: 'accepted' as const
+      };
+
+      await expect(handler.runTool(args, mockOAuth2Client)).rejects.toThrow(
+        'You are the organizer of this event. Organizers do not respond to their own event invitations.'
+      );
+    });
+
+    it('should throw error when event not found', async () => {
+      mockCalendar.events.get.mockResolvedValue({ data: null });
+
+      const args = {
+        calendarId: 'primary',
+        eventId: 'nonexistent',
+        response: 'accepted' as const
+      };
+
+      await expect(handler.runTool(args, mockOAuth2Client)).rejects.toThrow('Event not found');
+    });
+
+    it('should throw error when event has no attendees', async () => {
+      const mockEvent = {
+        id: 'event123',
+        summary: 'Solo Event',
+        start: { dateTime: '2025-01-15T10:00:00Z' },
+        end: { dateTime: '2025-01-15T11:00:00Z' }
+        // No attendees
+      };
+
+      mockCalendar.events.get.mockResolvedValue({ data: mockEvent });
+
+      const args = {
+        calendarId: 'primary',
+        eventId: 'event123',
+        response: 'accepted' as const
+      };
+
+      await expect(handler.runTool(args, mockOAuth2Client)).rejects.toThrow(
+        'You are not an attendee of this event. Only attendees can respond to event invitations.'
+      );
+    });
+
+    it('should handle patch failure', async () => {
+      const mockEvent = {
+        id: 'event123',
+        summary: 'Team Meeting',
+        attendees: [
+          { email: 'self@example.com', self: true, responseStatus: 'needsAction' }
+        ]
+      };
+
+      mockCalendar.events.get.mockResolvedValue({ data: mockEvent });
+      mockCalendar.events.patch.mockResolvedValue({ data: null });
+
+      const args = {
+        calendarId: 'primary',
+        eventId: 'event123',
+        response: 'accepted' as const
+      };
+
+      await expect(handler.runTool(args, mockOAuth2Client)).rejects.toThrow(
+        'Failed to update event response'
+      );
+    });
+
+    it('should handle API errors gracefully', async () => {
+      const apiError = new Error('API Error');
+      (apiError as any).code = 500;
+      mockCalendar.events.get.mockRejectedValue(apiError);
+
+      const args = {
+        calendarId: 'primary',
+        eventId: 'event123',
+        response: 'accepted' as const
+      };
+
+      // Mock handleGoogleApiError
+      vi.spyOn(handler as any, 'handleGoogleApiError').mockImplementation(() => {
+        throw new Error('Handled API Error');
+      });
+
+      await expect(handler.runTool(args, mockOAuth2Client)).rejects.toThrow('Handled API Error');
+    });
+
+    it('should preserve other attendee properties when updating response', async () => {
+      const mockEvent = {
+        id: 'event123',
+        summary: 'Team Meeting',
+        start: { dateTime: '2025-01-15T10:00:00Z' },
+        end: { dateTime: '2025-01-15T11:00:00Z' },
+        attendees: [
+          { email: 'organizer@example.com', organizer: true, responseStatus: 'accepted' },
+          {
+            email: 'self@example.com',
+            self: true,
+            responseStatus: 'needsAction',
+            displayName: 'My Name',
+            optional: false,
+            comment: 'Looking forward to it'
+          }
+        ]
+      };
+
+      const updatedEvent = { ...mockEvent };
+      mockCalendar.events.get.mockResolvedValue({ data: mockEvent });
+      mockCalendar.events.patch.mockResolvedValue({ data: updatedEvent });
+
+      const args = {
+        calendarId: 'primary',
+        eventId: 'event123',
+        response: 'accepted' as const
+      };
+
+      await handler.runTool(args, mockOAuth2Client);
+
+      expect(mockCalendar.events.patch).toHaveBeenCalledWith({
+        calendarId: 'primary',
+        eventId: 'event123',
+        requestBody: {
+          attendees: expect.arrayContaining([
+            expect.objectContaining({
+              email: 'self@example.com',
+              self: true,
+              responseStatus: 'accepted',
+              displayName: 'My Name',
+              optional: false,
+              comment: 'Looking forward to it'
+            })
+          ])
+        },
+        sendUpdates: 'all'
+      });
+    });
+  });
+
+  describe('Comment Support', () => {
+    it('should include comment when declining', async () => {
+      const mockEvent = {
+        id: 'event123',
+        summary: 'Team Meeting',
+        start: { dateTime: '2025-01-15T10:00:00Z' },
+        end: { dateTime: '2025-01-15T11:00:00Z' },
+        attendees: [
+          { email: 'organizer@example.com', organizer: true, responseStatus: 'accepted' },
+          { email: 'self@example.com', self: true, responseStatus: 'needsAction' }
+        ]
+      };
+
+      const updatedEvent = {
+        ...mockEvent,
+        attendees: [
+          { email: 'organizer@example.com', organizer: true, responseStatus: 'accepted' },
+          { email: 'self@example.com', self: true, responseStatus: 'declined', comment: 'I have a conflict' }
+        ]
+      };
+
+      mockCalendar.events.get.mockResolvedValue({ data: mockEvent });
+      mockCalendar.events.patch.mockResolvedValue({ data: updatedEvent });
+
+      const args = {
+        calendarId: 'primary',
+        eventId: 'event123',
+        response: 'declined' as const,
+        comment: 'I have a conflict'
+      };
+
+      const result = await handler.runTool(args, mockOAuth2Client);
+
+      expect(mockCalendar.events.patch).toHaveBeenCalledWith({
+        calendarId: 'primary',
+        eventId: 'event123',
+        requestBody: {
+          attendees: expect.arrayContaining([
+            expect.objectContaining({
+              responseStatus: 'declined',
+              comment: 'I have a conflict'
+            })
+          ])
+        },
+        sendUpdates: 'all'
+      });
+
+      const response = JSON.parse(result.content[0].text);
+      expect(response.message).toContain('I have a conflict');
+    });
+
+    it('should include comment when accepting', async () => {
+      const mockEvent = {
+        id: 'event123',
+        summary: 'Team Meeting',
+        attendees: [
+          { email: 'self@example.com', self: true, responseStatus: 'needsAction' }
+        ]
+      };
+
+      mockCalendar.events.get.mockResolvedValue({ data: mockEvent });
+      mockCalendar.events.patch.mockResolvedValue({ data: mockEvent });
+
+      const args = {
+        calendarId: 'primary',
+        eventId: 'event123',
+        response: 'accepted' as const,
+        comment: 'Looking forward to it!'
+      };
+
+      const result = await handler.runTool(args, mockOAuth2Client);
+
+      const response = JSON.parse(result.content[0].text);
+      expect(response.message).toContain('Looking forward to it!');
+    });
+
+    it('should not include comment field when comment is not provided', async () => {
+      const mockEvent = {
+        id: 'event123',
+        summary: 'Team Meeting',
+        attendees: [
+          { email: 'self@example.com', self: true, responseStatus: 'needsAction' }
+        ]
+      };
+
+      mockCalendar.events.get.mockResolvedValue({ data: mockEvent });
+      mockCalendar.events.patch.mockResolvedValue({ data: mockEvent });
+
+      const args = {
+        calendarId: 'primary',
+        eventId: 'event123',
+        response: 'accepted' as const
+      };
+
+      await handler.runTool(args, mockOAuth2Client);
+
+      const patchCall = mockCalendar.events.patch.mock.calls[0][0];
+      const updatedAttendee = patchCall.requestBody.attendees[0];
+
+      expect(updatedAttendee.responseStatus).toBe('accepted');
+      expect(updatedAttendee).not.toHaveProperty('comment');
+    });
+  });
+
+  describe('Recurring Event Support', () => {
+    it('should respond to single instance of recurring event', async () => {
+      const mockRecurringEvent = {
+        id: 'recurring123',
+        summary: 'Weekly Standup',
+        recurrence: ['RRULE:FREQ=WEEKLY;COUNT=10'],
+        attendees: [
+          { email: 'self@example.com', self: true, responseStatus: 'needsAction' }
+        ]
+      };
+
+      // Mock detectEventType to return 'recurring'
+      vi.spyOn(handler as any, 'getCalendar').mockReturnValue({
+        events: {
+          get: vi.fn()
+            .mockResolvedValueOnce({ data: mockRecurringEvent }) // For detectEventType
+            .mockResolvedValueOnce({ data: mockRecurringEvent }), // For actual get
+          patch: vi.fn().mockResolvedValue({ data: mockRecurringEvent })
+        }
+      });
+
+      const args = {
+        calendarId: 'primary',
+        eventId: 'recurring123',
+        response: 'accepted' as const,
+        modificationScope: 'thisEventOnly' as const,
+        originalStartTime: '2025-01-15T10:00:00Z'
+      };
+
+      const result = await handler.runTool(args, mockOAuth2Client);
+
+      // Verify the instance ID was used (formatted with underscore and timestamp)
+      const calendar = (handler as any).getCalendar(mockOAuth2Client);
+      expect(calendar.events.patch).toHaveBeenCalled();
+
+      const patchCall = calendar.events.patch.mock.calls[0][0];
+      expect(patchCall.eventId).toContain('recurring123_');
+      expect(patchCall.eventId).toContain('20250115T100000Z');
+
+      const response = JSON.parse(result.content[0].text);
+      expect(response.message).toContain('this instance only');
+    });
+
+    it('should respond to all instances of recurring event', async () => {
+      const mockRecurringEvent = {
+        id: 'recurring123',
+        summary: 'Weekly Standup',
+        recurrence: ['RRULE:FREQ=WEEKLY;COUNT=10'],
+        attendees: [
+          { email: 'self@example.com', self: true, responseStatus: 'needsAction' }
+        ]
+      };
+
+      mockCalendar.events.get.mockResolvedValue({ data: mockRecurringEvent });
+      mockCalendar.events.patch.mockResolvedValue({ data: mockRecurringEvent });
+
+      const args = {
+        calendarId: 'primary',
+        eventId: 'recurring123',
+        response: 'declined' as const,
+        modificationScope: 'all' as const
+      };
+
+      const result = await handler.runTool(args, mockOAuth2Client);
+
+      // Verify the base event ID was used
+      expect(mockCalendar.events.patch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          eventId: 'recurring123'
+        })
+      );
+
+      const response = JSON.parse(result.content[0].text);
+      expect(response.message).toContain('all instances');
+    });
+
+    it('should throw error when originalStartTime missing for thisEventOnly', async () => {
+      const args = {
+        calendarId: 'primary',
+        eventId: 'recurring123',
+        response: 'accepted' as const,
+        modificationScope: 'thisEventOnly' as const
+        // Missing originalStartTime
+      };
+
+      await expect(handler.runTool(args, mockOAuth2Client)).rejects.toThrow(
+        'originalStartTime is required'
+      );
+    });
+
+    it('should throw error when using thisEventOnly on non-recurring event', async () => {
+      const mockSingleEvent = {
+        id: 'single123',
+        summary: 'One-time Meeting',
+        attendees: [
+          { email: 'self@example.com', self: true, responseStatus: 'needsAction' }
+        ]
+        // No recurrence property
+      };
+
+      mockCalendar.events.get.mockResolvedValue({ data: mockSingleEvent });
+
+      const args = {
+        calendarId: 'primary',
+        eventId: 'single123',
+        response: 'accepted' as const,
+        modificationScope: 'thisEventOnly' as const,
+        originalStartTime: '2025-01-15T10:00:00Z'
+      };
+
+      await expect(handler.runTool(args, mockOAuth2Client)).rejects.toThrow(
+        'can only be used with recurring events'
+      );
+    });
+
+    it('should use base event ID when no modificationScope specified', async () => {
+      const mockRecurringEvent = {
+        id: 'recurring123',
+        summary: 'Weekly Standup',
+        recurrence: ['RRULE:FREQ=WEEKLY;COUNT=10'],
+        attendees: [
+          { email: 'self@example.com', self: true, responseStatus: 'needsAction' }
+        ]
+      };
+
+      mockCalendar.events.get.mockResolvedValue({ data: mockRecurringEvent });
+      mockCalendar.events.patch.mockResolvedValue({ data: mockRecurringEvent });
+
+      const args = {
+        calendarId: 'primary',
+        eventId: 'recurring123',
+        response: 'tentative' as const
+        // No modificationScope - should default to 'all' behavior
+      };
+
+      await handler.runTool(args, mockOAuth2Client);
+
+      // Verify the base event ID was used (not instance-specific)
+      expect(mockCalendar.events.patch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          eventId: 'recurring123'
+        })
+      );
+    });
+  });
+});

--- a/src/types/structured-responses.ts
+++ b/src/types/structured-responses.ts
@@ -229,6 +229,15 @@ export interface DeleteEventResponse {
 }
 
 /**
+ * Response format for responding to an event invitation
+ */
+export interface RespondToEventResponse {
+  event: StructuredEvent;
+  responseStatus: 'accepted' | 'declined' | 'tentative' | 'needsAction';
+  message: string;
+}
+
+/**
  * Detailed information about a calendar
  */
 export interface CalendarInfo {


### PR DESCRIPTION
Implements a new `respond-to-event` MCP tool that allows users to respond to calendar event invitations.

Closes #124

  ## Features
  - ✅ Response types: Accept, Decline, Maybe (Tentative), No Response
  - ✅ Optional comment/note with response (e.g., "I have a scheduling conflict")
  - ✅ Recurring event support: respond to single instance or all instances
  - ✅ Full Google Calendar API integration
  - ✅ Comprehensive error handling and validation

  ## Changes
  - Add `RespondToEventHandler` following existing handler patterns
  - Add schema with validation for `comment`, `modificationScope`, `originalStartTime`
  - Add `RespondToEventResponse` structured response type
  - Add 11 unit tests (408 total tests pass)
  - Add 3 integration tests for real API validation
  - Update README with usage examples
  - Reuse existing `RecurringEventHelpers` infrastructure

  ## Usage Examples

  **Simple response:**
  Accept the team meeting tomorrow

  **Response with note:**
  Decline Friday's meeting with a note that I have a conflict

  **Recurring events:**
  Accept just this week's standup, but keep future instances as tentative

  ## Testing
  - ✅ All 408 unit tests pass
  - ✅ TypeScript compilation successful
  - ✅ Integration tests added for comment and recurring event features