### PR TITLE
fix: add reminders and recurrence to default event fields (#128)

### DIFF
--- a/src/utils/field-mask-builder.ts
+++ b/src/utils/field-mask-builder.ts
@@ -51,7 +51,9 @@ export const DEFAULT_EVENT_FIELDS: AllowedEventField[] = [
   'status',
   'htmlLink',
   'location',
-  'attendees'
+  'attendees',
+  'reminders',
+  'recurrence'
 ];
 
 /**


### PR DESCRIPTION
## Summary
- Adds `reminders` and `recurrence` to the `DEFAULT_EVENT_FIELDS` array in `field-mask-builder.ts`
- Ensures these fields are returned by default in `get-event`, `list-events`, and `search-events` tools

## Problem
Issue #128 reported that the `get-event` method was not returning reminders and recurrence information, which are important event details.

## Solution
The infrastructure to support these fields already existed:
- The `StructuredEvent` interface includes both fields
- The `convertGoogleEventToStructured()` function handles them
- Both fields are in the `ALLOWED_EVENT_FIELDS` list

The fix was simply adding them to the `DEFAULT_EVENT_FIELDS` array so they're retrieved automatically without requiring explicit field parameters.

## Changes
- **Modified**: `src/utils/field-mask-builder.ts` - Added `reminders` and `recurrence` to DEFAULT_EVENT_FIELDS (lines 55-56)

## Testing
- ✅ All field-mask-builder unit tests pass
- ✅ Integration tests confirm reminders field is now included in API responses
- ✅ Backward compatible - no breaking changes

## Impact
All event retrieval tools now include reminders and recurrence by default:
- `get-event`
- `list-events` 
- `search-events`

Resolves #128