### PR TITLE
feat: Add per-field timezone support for start/end times

### DIFF
--- a/src/tests/unit/handlers/datetime-utils.test.ts
+++ b/src/tests/unit/handlers/datetime-utils.test.ts
@@ -45,23 +45,153 @@ describe('Datetime Utilities', () => {
   });
 
   describe('createTimeObject', () => {
-    it('should create time object without timeZone for timezone-aware datetime', () => {
-      const datetime = '2024-01-01T10:00:00Z';
-      const result = createTimeObject(datetime, 'America/Los_Angeles');
-      
-      expect(result).toEqual({
-        dateTime: datetime
+    describe('string format (ISO 8601)', () => {
+      it('should create time object without timeZone for timezone-aware datetime', () => {
+        const datetime = '2024-01-01T10:00:00Z';
+        const result = createTimeObject(datetime, 'America/Los_Angeles');
+
+        expect(result).toEqual({
+          dateTime: datetime
+        });
+      });
+
+      it('should create time object with timeZone for timezone-naive datetime', () => {
+        const datetime = '2024-01-01T10:00:00';
+        const timezone = 'America/Los_Angeles';
+        const result = createTimeObject(datetime, timezone);
+
+        expect(result).toEqual({
+          dateTime: datetime,
+          timeZone: timezone
+        });
+      });
+
+      it('should create date object for all-day events (date-only format)', () => {
+        const date = '2024-01-01';
+        const result = createTimeObject(date, 'America/Los_Angeles');
+
+        expect(result).toEqual({
+          date: date
+        });
+      });
+
+      it('should handle datetime with positive offset', () => {
+        const datetime = '2024-01-01T10:00:00+05:30';
+        const result = createTimeObject(datetime, 'America/Los_Angeles');
+
+        expect(result).toEqual({
+          dateTime: datetime
+        });
+      });
+
+      it('should handle datetime with negative offset', () => {
+        const datetime = '2024-01-01T10:00:00-08:00';
+        const result = createTimeObject(datetime, 'America/Los_Angeles');
+
+        expect(result).toEqual({
+          dateTime: datetime
+        });
       });
     });
 
-    it('should create time object with timeZone for timezone-naive datetime', () => {
-      const datetime = '2024-01-01T10:00:00';
-      const timezone = 'America/Los_Angeles';
-      const result = createTimeObject(datetime, timezone);
-      
-      expect(result).toEqual({
-        dateTime: datetime,
-        timeZone: timezone
+    describe('JSON object format (per-field timezone)', () => {
+      it('should parse JSON with dateTime and timeZone', () => {
+        const input = '{"dateTime": "2024-01-01T10:00:00", "timeZone": "America/New_York"}';
+        const result = createTimeObject(input, 'America/Los_Angeles');
+
+        expect(result).toEqual({
+          dateTime: '2024-01-01T10:00:00',
+          timeZone: 'America/New_York'  // Uses per-field timezone, not fallback
+        });
+      });
+
+      it('should parse JSON with dateTime only (uses fallback timezone)', () => {
+        const input = '{"dateTime": "2024-01-01T10:00:00"}';
+        const result = createTimeObject(input, 'America/Los_Angeles');
+
+        expect(result).toEqual({
+          dateTime: '2024-01-01T10:00:00',
+          timeZone: 'America/Los_Angeles'  // Falls back to provided timezone
+        });
+      });
+
+      it('should parse JSON with timezone-aware dateTime (ignores timeZone field)', () => {
+        const input = '{"dateTime": "2024-01-01T10:00:00Z", "timeZone": "America/New_York"}';
+        const result = createTimeObject(input, 'America/Los_Angeles');
+
+        expect(result).toEqual({
+          dateTime: '2024-01-01T10:00:00Z'  // Embedded timezone takes precedence
+        });
+      });
+
+      it('should parse JSON with date for all-day events', () => {
+        const input = '{"date": "2024-01-01"}';
+        const result = createTimeObject(input, 'America/Los_Angeles');
+
+        expect(result).toEqual({
+          date: '2024-01-01'
+        });
+      });
+
+      it('should throw error for invalid JSON', () => {
+        const input = '{invalid json}';
+
+        expect(() => createTimeObject(input, 'America/Los_Angeles'))
+          .toThrow('Invalid JSON in time input');
+      });
+
+      it('should throw error for JSON with neither date nor dateTime', () => {
+        const input = '{"timeZone": "America/New_York"}';
+
+        expect(() => createTimeObject(input, 'America/Los_Angeles'))
+          .toThrow('Invalid time object: must have either dateTime or date');
+      });
+
+      it('should handle JSON with extra whitespace in values', () => {
+        const input = '{"dateTime": "2024-01-01T10:00:00", "timeZone": "America/New_York"}';
+        const result = createTimeObject(input, 'America/Los_Angeles');
+
+        expect(result.timeZone).toBe('America/New_York');
+      });
+
+      it('should handle JSON with leading/trailing whitespace', () => {
+        const input = '  {"dateTime": "2024-01-01T10:00:00", "timeZone": "America/New_York"}  ';
+        const result = createTimeObject(input, 'America/Los_Angeles');
+
+        expect(result).toEqual({
+          dateTime: '2024-01-01T10:00:00',
+          timeZone: 'America/New_York'
+        });
+      });
+
+      it('should handle string datetime with leading/trailing whitespace', () => {
+        const input = '  2024-01-01T10:00:00  ';
+        const result = createTimeObject(input, 'America/Los_Angeles');
+
+        expect(result).toEqual({
+          dateTime: '2024-01-01T10:00:00',
+          timeZone: 'America/Los_Angeles'
+        });
+      });
+    });
+
+    describe('flight booking use case (different start/end timezones)', () => {
+      it('should support LA to NYC flight with correct timezones', () => {
+        // Flight departs LA at 8am Pacific, arrives NYC at 4:30pm Eastern
+        const startInput = '{"dateTime": "2024-01-15T08:00:00", "timeZone": "America/Los_Angeles"}';
+        const endInput = '{"dateTime": "2024-01-15T16:30:00", "timeZone": "America/New_York"}';
+
+        const startResult = createTimeObject(startInput, 'UTC');
+        const endResult = createTimeObject(endInput, 'UTC');
+
+        expect(startResult).toEqual({
+          dateTime: '2024-01-15T08:00:00',
+          timeZone: 'America/Los_Angeles'
+        });
+        expect(endResult).toEqual({
+          dateTime: '2024-01-15T16:30:00',
+          timeZone: 'America/New_York'
+        });
       });
     });
   });


### PR DESCRIPTION
## Summary

Enable different timezones for event start and end times by accepting JSON-encoded objects with per-field `timeZone` properties.

This is useful for events that span multiple timezones, such as:
- ✈️ Flights departing in one timezone and arriving in another
- 🌍 Multi-city meetings
- 🗺️ Travel itineraries

## Usage

**String format (unchanged - full backward compatibility):**
- `"2025-01-01T10:00:00"` (uses event/calendar timezone)
- `"2025-01-01"` (all-day event)

**New JSON object format with per-field timezone:**
```
'{"dateTime": "2025-01-01T10:00:00", "timeZone": "America/Los_Angeles"}'
'{"dateTime": "2025-01-01T17:00:00", "timeZone": "America/New_York"}'
'{"date": "2025-01-01"}'  // all-day event
```

## Example: Flight from LA to NYC

```json
{
  "summary": "Flight LAX > JFK",
  "start": "{\"dateTime\": \"2025-01-15T08:00:00\", \"timeZone\": \"America/Los_Angeles\"}",
  "end": "{\"dateTime\": \"2025-01-15T16:30:00\", \"timeZone\": \"America/New_York\"}"
}
```

This creates an event that correctly shows:
- **Departure:** 8:00 AM Pacific Time (at LAX)
- **Arrival:** 4:30 PM Eastern Time (at JFK)

The calendar event spans the correct duration and displays times in their respective local timezones.

## Implementation Details

- Schema validation accepts both ISO 8601 strings and JSON-encoded objects
- `createTimeObject()` in `datetime.ts` parses JSON strings and extracts per-field timezone
- Handles leading/trailing whitespace in inputs gracefully
- Maintains **full backward compatibility** with existing string format
- No breaking changes to existing integrations
- Updated `focusTime`/`outOfOffice` event validation to handle both formats

## Test Coverage

Added 13 new unit tests covering:
- [x] JSON object format with dateTime and timeZone
- [x] JSON object format with dateTime only (fallback to calendar timezone)
- [x] JSON object format with timezone-aware dateTime (embedded TZ takes precedence)
- [x] JSON object format for all-day events
- [x] Invalid JSON error handling
- [x] Missing dateTime/date error handling
- [x] Leading/trailing whitespace handling
- [x] Flight booking use case (different start/end timezones)
- [x] All existing tests continue to pass (739 total)

## Test plan

- [x] All 739 unit tests pass
- [x] Build succeeds
- [x] TypeScript compilation passes
- [ ] Manual testing with Claude Desktop for flight booking use case

🤖 Generated with [Claude Code](https://claude.ai/code)