### PR TITLE
fix: detect recurring event instances via recurringEventId

### DIFF
--- a/src/handlers/core/RecurringEventHelpers.ts
+++ b/src/handlers/core/RecurringEventHelpers.ts
@@ -25,7 +25,10 @@ export class RecurringEventHelpers {
     });
 
     const event = response.data;
-    return event.recurrence && event.recurrence.length > 0 ? 'recurring' : 'single';
+    // Check both recurrence array (parent events) and recurringEventId (instances)
+    if (event.recurrence && event.recurrence.length > 0) return 'recurring';
+    if (event.recurringEventId) return 'recurring';
+    return 'single';
   }
 
   /**

--- a/src/tests/unit/handlers/RecurringEventHelpers.test.ts
+++ b/src/tests/unit/handlers/RecurringEventHelpers.test.ts
@@ -64,6 +64,21 @@ describe('RecurringEventHelpers', () => {
       expect(result).toBe('single');
     });
 
+    it('should detect recurring event instances via recurringEventId', async () => {
+      const mockEvent = {
+        data: {
+          id: 'event123_20260127T180000Z',
+          summary: 'Weekly Meeting',
+          recurringEventId: 'event123'
+          // no recurrence array - instances don't carry it
+        }
+      };
+      mockCalendar.events.get.mockResolvedValue(mockEvent);
+
+      const result = await helpers.detectEventType('event123_20260127T180000Z', 'primary');
+      expect(result).toBe('recurring');
+    });
+
     it('should handle API errors', async () => {
       mockCalendar.events.get.mockRejectedValue(new Error('Event not found'));
 


### PR DESCRIPTION
## Summary

Fixes #163 — `detectEventType()` misidentifies recurring event instances as single events.

- `detectEventType()` now checks `event.recurringEventId` in addition to `event.recurrence`, correctly identifying both parent recurring events and their individual instances
- Added test case for instance detection via `recurringEventId`

## Problem

Recurring event **instances** (returned by `list-events`, `search-events`) don't carry the `recurrence` array — only the parent event does. Instances instead have `recurringEventId`. The existing code only checked `recurrence`, causing all instances to be classified as `'single'`, which made `modificationScope: 'thisEventOnly'` always throw:

```
"Scope other than 'all' only applies to recurring events"
```

This forces AI agents into a 2-3 attempt retry loop on every recurring event modification.

## Changes

- **`src/handlers/core/RecurringEventHelpers.ts`**: Added `recurringEventId` check in `detectEventType()`
- **`src/tests/unit/handlers/RecurringEventHelpers.test.ts`**: Added test for instance detection

## Test plan

- [x] `npm run lint` — passes
- [x] `npm run build` — passes  
- [x] `npm test` — all 707 unit tests pass (including new test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)