### PR TITLE
feat: per-field timezone support for start/end times

### DIFF
--- a/src/tests/unit/handlers/datetime-utils.test.ts
+++ b/src/tests/unit/handlers/datetime-utils.test.ts
@@ -180,6 +180,13 @@ describe('Datetime Utilities', () => {
           .toThrow('timeZone cannot be empty');
       });
 
+      it('should throw error for non-string timeZone value', () => {
+        const input = '{"dateTime": "2024-01-01T10:00:00", "timeZone": 123}';
+
+        expect(() => createTimeObject(input, 'America/Los_Angeles'))
+          .toThrow('timeZone must be a string');
+      });
+
       it('should handle JSON with extra whitespace in values', () => {
         const input = '{"dateTime": "2024-01-01T10:00:00", "timeZone": "America/New_York"}';
         const result = createTimeObject(input, 'America/Los_Angeles');

--- a/src/tests/unit/schemas/validators.test.ts
+++ b/src/tests/unit/schemas/validators.test.ts
@@ -459,6 +459,17 @@ describe('Per-field timezone validation', () => {
       expect(() => CreateEventSchema.parse(input)).toThrow(/timeZone cannot be empty/);
     });
 
+    it('should reject non-string timeZone value', () => {
+      const input = {
+        calendarId: 'primary',
+        summary: 'Test',
+        start: '{"dateTime": "2024-01-01T10:00:00", "timeZone": 123}',
+        end: '2024-01-01T11:00:00'
+      };
+
+      expect(() => CreateEventSchema.parse(input)).toThrow(/timeZone must be a string/);
+    });
+
     it('should reject invalid JSON', () => {
       const input = {
         calendarId: 'primary',

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -56,8 +56,13 @@ const validateTimeInput = (val: string): string | true => {
       return ISO_DATE_ONLY.test(obj.date) ? true : "Invalid date format: must be YYYY-MM-DD (e.g., '2025-01-01')";
     }
     if (obj.dateTime !== undefined) {
-      if (obj.timeZone !== undefined && typeof obj.timeZone === 'string' && obj.timeZone.trim() === '') {
-        return "timeZone cannot be empty - provide a valid IANA timezone (e.g., 'America/Los_Angeles') or omit the field";
+      if (obj.timeZone !== undefined) {
+        if (typeof obj.timeZone !== 'string') {
+          return "timeZone must be a string (IANA timezone, e.g., 'America/Los_Angeles')";
+        }
+        if (obj.timeZone.trim() === '') {
+          return "timeZone cannot be empty - provide a valid IANA timezone (e.g., 'America/Los_Angeles') or omit the field";
+        }
       }
       return isValidIsoDateTime(obj.dateTime) ? true : "Invalid dateTime format: must be ISO 8601 (e.g., '2025-01-01T10:00:00')";
     }

--- a/src/utils/datetime.ts
+++ b/src/utils/datetime.ts
@@ -132,9 +132,14 @@ export function createTimeObject(input: string, fallbackTimezone: string): { dat
                 return { date: obj.date };
             }
             if (obj.dateTime) {
-                // Validate timeZone is not empty if provided
-                if (obj.timeZone !== undefined && obj.timeZone.trim() === '') {
-                    throw new Error("timeZone cannot be empty - provide a valid IANA timezone (e.g., 'America/Los_Angeles') or omit the field");
+                // Validate timeZone type and value if provided
+                if (obj.timeZone !== undefined) {
+                    if (typeof obj.timeZone !== 'string') {
+                        throw new Error("timeZone must be a string (IANA timezone, e.g., 'America/Los_Angeles')");
+                    }
+                    if (obj.timeZone.trim() === '') {
+                        throw new Error("timeZone cannot be empty - provide a valid IANA timezone (e.g., 'America/Los_Angeles') or omit the field");
+                    }
                 }
                 // Timed event via JSON object format
                 if (hasTimezoneInDatetime(obj.dateTime)) {


### PR DESCRIPTION
## Summary

Adds per-field timezone support for event start/end times, enabling different timezones for each (e.g., flights departing in one timezone and arriving in another). Supersedes #161 with additional validation improvements.

- Accept JSON-encoded objects with per-field `timeZone` for start/end: `'{"dateTime": "2025-01-15T08:00:00", "timeZone": "America/Los_Angeles"}'`
- Full backward compatibility with existing ISO 8601 string format
- Specific validation error messages for all failure modes (both date+dateTime, empty timeZone, invalid JSON, missing fields)
- Use `.superRefine()` for Zod 4 compatibility with dynamic error messages
- Schema descriptions document timezone precedence rules
- Don't echo raw input in error messages

## Test plan

- [x] 748 unit tests pass
- [x] Build and lint clean
- [ ] Manual testing with Claude Desktop for flight booking use case

Closes #161