### PR TITLE
docs: add authentication step to First Run section

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ See the [Docker deployment guide](docs/docker.md) for detailed configuration opt
 ### First Run
 
 1. Start Claude Desktop
-2. The server will prompt for authentication on first use
+2. **Ask Claude to authenticate with the Google Calendar MCP server** (e.g., "Authenticate with Google Calendar"). This step is required before using any calendar tool — without it, requests will fail with a `-32600` error.
 3. Complete the OAuth flow in your browser
 4. You're ready to use calendar features!
 

--- a/README.md
+++ b/README.md
@@ -86,10 +86,12 @@ See the [Docker deployment guide](docs/docker.md) for detailed configuration opt
 
 ### First Run
 
-1. Start your MCP client (e.g., Claude Desktop, Claude Code)
+1. Start Claude Desktop
 2. **Ask Claude to authenticate with the Google Calendar MCP server** (e.g., "Authenticate with Google Calendar"). This step is required before using any calendar tool — without it, requests will fail with a `-32600` error.
 3. Complete the OAuth flow in your browser
 4. You're ready to use calendar features!
+
+**Using Claude Code?** The same steps apply — just ask Claude to authenticate with the Google Calendar MCP server from your CLI session before using any calendar tool.
 
 ### Re-authentication
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ See the [Docker deployment guide](docs/docker.md) for detailed configuration opt
 
 ### First Run
 
-1. Start Claude Desktop
+1. Start your MCP client (e.g., Claude Desktop, Claude Code)
 2. **Ask Claude to authenticate with the Google Calendar MCP server** (e.g., "Authenticate with Google Calendar"). This step is required before using any calendar tool — without it, requests will fail with a `-32600` error.
 3. Complete the OAuth flow in your browser
 4. You're ready to use calendar features!


### PR DESCRIPTION
## Summary

- Added a clear step in the **First Run** section of the README instructing users to ask Claude to authenticate with the Google Calendar MCP server before using any calendar tools.
- Without this step, users get a `-32600` error on first use, which is not intuitive.

## Context

The current "First Run" instructions say the server will "prompt for authentication on first use," but in practice, users need to explicitly ask Claude to authenticate with the MCP server. Without doing so, all calendar tool requests fail with error `-32600`. This small documentation update makes that requirement explicit.

## Test plan

- [x] Verified the README renders correctly with the updated instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)