### PR TITLE
Replace z.string().email() with RE2-safe regex (fixes lookaround in tool schemas)

### DIFF
--- a/src/tests/unit/schemas/no-refs.test.ts
+++ b/src/tests/unit/schemas/no-refs.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { ToolRegistry } from '../../../tools/registry.js';
+import { z } from 'zod';
+import { ToolRegistry, ToolSchemas } from '../../../tools/registry.js';
 
 describe('Schema $ref Prevention Tests', () => {
   it('should not generate $ref references in JSON schemas, causes issues with Claude Desktop', () => {
@@ -71,6 +72,34 @@ describe('Schema $ref Prevention Tests', () => {
         console.error(`Found potentially problematic schema usage: ${matches[0]}`);
         expect(matches).toBeNull();
       }
+    }
+  });
+
+  it('should not emit regex lookaround in JSON schema patterns, rejected by RE2 validators (OpenAI, Gemini)', () => {
+    const lookaround = /\(\?[=!<]/;
+
+    const collectPatterns = (node: unknown, acc: string[]): string[] => {
+      if (Array.isArray(node)) {
+        for (const item of node) collectPatterns(item, acc);
+      } else if (node && typeof node === 'object') {
+        for (const [key, value] of Object.entries(node)) {
+          if (key === 'pattern' && typeof value === 'string') acc.push(value);
+          collectPatterns(value, acc);
+        }
+      }
+      return acc;
+    };
+
+    for (const [name, schema] of Object.entries(ToolSchemas)) {
+      const jsonSchema = z.toJSONSchema(schema, { io: 'input' });
+      const patterns = collectPatterns(jsonSchema, []);
+      const offenders = patterns.filter((p) => lookaround.test(p));
+
+      if (offenders.length > 0) {
+        console.error(`Tool "${name}" emits lookaround in pattern(s):`, offenders);
+      }
+
+      expect(offenders).toEqual([]);
     }
   });
 });

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -223,6 +223,11 @@ const singleAccountSchema = z.string()
 // Account ID validation regex
 const accountIdRegex = /^[a-z0-9_-]{1,64}$/;
 
+// Email validation regex - RE2-safe (no lookaround). zod's .email() emits a
+// JSON Schema pattern with negative lookahead that RE2-based validators
+// (OpenAI, Gemini) reject; the Calendar API validates emails server-side anyway.
+const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
 // Multi-account schema - for read operations (list, search, get)
 const multiAccountSchema = z.preprocess(
   parseJsonStringArray,
@@ -356,7 +361,7 @@ export const ToolSchemas = {
     ),
     location: z.string().optional().describe("Location of the event"),
     attendees: z.array(z.object({
-      email: z.string().regex(/^[^\s@]+@[^\s@]+\.[^\s@]+$/, "Invalid email address").describe("Email address of the attendee"),
+      email: z.string().regex(emailRegex, "Invalid email address").describe("Email address of the attendee"),
       displayName: z.string().optional().describe("Display name of the attendee"),
       optional: z.boolean().optional().describe("Whether this is an optional attendee"),
       responseStatus: z.enum(RESPONSE_STATUS_VALUES).optional().describe("Attendee's response status"),
@@ -515,7 +520,7 @@ export const ToolSchemas = {
       description: z.string().optional().describe("Description/notes for the event"),
       location: z.string().optional().describe("Location of the event"),
       attendees: z.array(z.object({
-        email: z.string().regex(/^[^\s@]+@[^\s@]+\.[^\s@]+$/, "Invalid email address").describe("Email address of the attendee"),
+        email: z.string().regex(emailRegex, "Invalid email address").describe("Email address of the attendee"),
         displayName: z.string().optional().describe("Display name of the attendee"),
         optional: z.boolean().optional().describe("Whether this is an optional attendee"),
         responseStatus: z.enum(["needsAction", "declined", "tentative", "accepted"]).optional().describe("Attendee's response status"),
@@ -579,7 +584,7 @@ export const ToolSchemas = {
     timeZone: z.string().optional().describe("Updated timezone as IANA Time Zone Database name. If not provided, uses the calendar's default timezone."),
     location: z.string().optional().describe("Updated location"),
     attendees: z.array(z.object({
-      email: z.string().regex(/^[^\s@]+@[^\s@]+\.[^\s@]+$/, "Invalid email address").describe("Email address of the attendee")
+      email: z.string().regex(emailRegex, "Invalid email address").describe("Email address of the attendee")
     })).optional().describe("Updated attendee list"),
     colorId: z.string().optional().describe("Updated color ID"),
     reminders: remindersSchema,

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -356,7 +356,7 @@ export const ToolSchemas = {
     ),
     location: z.string().optional().describe("Location of the event"),
     attendees: z.array(z.object({
-      email: z.string().email().describe("Email address of the attendee"),
+      email: z.string().regex(/^[^\s@]+@[^\s@]+\.[^\s@]+$/, "Invalid email address").describe("Email address of the attendee"),
       displayName: z.string().optional().describe("Display name of the attendee"),
       optional: z.boolean().optional().describe("Whether this is an optional attendee"),
       responseStatus: z.enum(RESPONSE_STATUS_VALUES).optional().describe("Attendee's response status"),
@@ -515,7 +515,7 @@ export const ToolSchemas = {
       description: z.string().optional().describe("Description/notes for the event"),
       location: z.string().optional().describe("Location of the event"),
       attendees: z.array(z.object({
-        email: z.string().email().describe("Email address of the attendee"),
+        email: z.string().regex(/^[^\s@]+@[^\s@]+\.[^\s@]+$/, "Invalid email address").describe("Email address of the attendee"),
         displayName: z.string().optional().describe("Display name of the attendee"),
         optional: z.boolean().optional().describe("Whether this is an optional attendee"),
         responseStatus: z.enum(["needsAction", "declined", "tentative", "accepted"]).optional().describe("Attendee's response status"),
@@ -579,7 +579,7 @@ export const ToolSchemas = {
     timeZone: z.string().optional().describe("Updated timezone as IANA Time Zone Database name. If not provided, uses the calendar's default timezone."),
     location: z.string().optional().describe("Updated location"),
     attendees: z.array(z.object({
-      email: z.string().email().describe("Email address of the attendee")
+      email: z.string().regex(/^[^\s@]+@[^\s@]+\.[^\s@]+$/, "Invalid email address").describe("Email address of the attendee")
     })).optional().describe("Updated attendee list"),
     colorId: z.string().optional().describe("Updated color ID"),
     reminders: remindersSchema,


### PR DESCRIPTION
Closes #183.

zod v4's `.email()` emits a JSON Schema `pattern` that contains negative lookahead (`(?!\.)`, `(?!.*\.\.)`). RE2-based tool schema validators (OpenAI GPT-4o/GPT-5, Google Gemini) reject lookaround, so the affected tools fail to load on those clients.

Three call sites in `src/tools/registry.ts` (`create-event`, `create-events`, `update-event`) replace `z.string().email()` with `z.string().regex(/^[^\s@]+@[^\s@]+\.[^\s@]+$/)`.

The Google Calendar API performs authoritative email validation server-side, so the lighter client-side regex is sufficient.

Happy to swap to `.refine()` (which emits no `pattern` at all) if the maintainers prefer — see issue #183 Option B.
