### PR TITLE
feat(auth): support OAuth credentials in "web" (Web application) format

### DIFF
--- a/src/auth/client.ts
+++ b/src/auth/client.ts
@@ -7,8 +7,14 @@ async function loadCredentialsFromFile(): Promise<OAuthCredentials> {
   const keys = JSON.parse(keysContent);
 
   if (keys.installed) {
-    // Standard OAuth credentials file format
+    // Standard OAuth credentials file format (Desktop app)
     const { client_id, client_secret, redirect_uris } = keys.installed;
+    return { client_id, client_secret, redirect_uris };
+  } else if (keys.web) {
+    // Web application OAuth credentials file format (e.g. when the OAuth
+    // client is created as "Web application" in Google Cloud Console — typical
+    // when a public HTTPS callback URL is required for an OAuth proxy/bridge).
+    const { client_id, client_secret, redirect_uris } = keys.web;
     return { client_id, client_secret, redirect_uris };
   } else if (keys.client_id && keys.client_secret) {
     // Direct format
@@ -18,7 +24,7 @@ async function loadCredentialsFromFile(): Promise<OAuthCredentials> {
       redirect_uris: keys.redirect_uris || ['http://localhost:3000/oauth2callback']
     };
   } else {
-    throw new Error('Invalid credentials file format. Expected either "installed" object or direct client_id/client_secret fields.');
+    throw new Error('Invalid credentials file format. Expected either "installed" object, "web" object, or direct client_id/client_secret fields.');
   }
 }
 

--- a/src/auth/utils.ts
+++ b/src/auth/utils.ts
@@ -65,6 +65,12 @@ export interface OAuthCredentialsWithProject {
     client_secret?: string;
     redirect_uris?: string[];
   };
+  web?: {
+    project_id?: string;
+    client_id?: string;
+    client_secret?: string;
+    redirect_uris?: string[];
+  };
   project_id?: string;
   client_id?: string;
   client_secret?: string;
@@ -85,9 +91,11 @@ export function getCredentialsProjectId(): string | undefined {
     const credentialsContent = fs.readFileSync(credentialsPath, 'utf-8');
     const credentials: OAuthCredentialsWithProject = JSON.parse(credentialsContent);
 
-    // Extract project_id from installed format or direct format
+    // Extract project_id from installed (Desktop) / web (Web app) / direct format
     if (credentials.installed?.project_id) {
       return credentials.installed.project_id;
+    } else if (credentials.web?.project_id) {
+      return credentials.web.project_id;
     } else if (credentials.project_id) {
       return credentials.project_id;
     }

--- a/src/tests/unit/auth/client.test.ts
+++ b/src/tests/unit/auth/client.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fsPromises from 'fs/promises';
+import * as fs from 'fs';
+
+vi.mock('fs/promises');
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>();
+  return {
+    ...actual,
+    existsSync: vi.fn(),
+    readFileSync: vi.fn(),
+  };
+});
+
+import { loadCredentials, initializeOAuth2Client } from '../../../auth/client.js';
+import { getCredentialsProjectId } from '../../../auth/utils.js';
+
+const FAKE_PATH = '/fake/path/gcp-oauth.keys.json';
+
+describe('loadCredentialsFromFile (via loadCredentials)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.GOOGLE_OAUTH_CREDENTIALS = FAKE_PATH;
+  });
+
+  afterEach(() => {
+    delete process.env.GOOGLE_OAUTH_CREDENTIALS;
+  });
+
+  it('parses the "installed" (Desktop app) format', async () => {
+    vi.mocked(fsPromises.readFile).mockResolvedValueOnce(JSON.stringify({
+      installed: {
+        client_id: 'desktop-client-id',
+        client_secret: 'desktop-secret',
+        redirect_uris: ['http://localhost:3000/oauth2callback'],
+      },
+    }));
+    const creds = await loadCredentials();
+    expect(creds).toEqual({ client_id: 'desktop-client-id', client_secret: 'desktop-secret' });
+  });
+
+  it('parses the "web" (Web application) format', async () => {
+    vi.mocked(fsPromises.readFile).mockResolvedValueOnce(JSON.stringify({
+      web: {
+        client_id: 'web-client-id',
+        client_secret: 'web-secret',
+        redirect_uris: ['https://example.com/oauth2callback'],
+      },
+    }));
+    const creds = await loadCredentials();
+    expect(creds).toEqual({ client_id: 'web-client-id', client_secret: 'web-secret' });
+  });
+
+  it('parses the direct (root-level) format', async () => {
+    vi.mocked(fsPromises.readFile).mockResolvedValueOnce(JSON.stringify({
+      client_id: 'direct-client-id',
+      client_secret: 'direct-secret',
+      redirect_uris: ['http://localhost:3000/oauth2callback'],
+    }));
+    const creds = await loadCredentials();
+    expect(creds).toEqual({ client_id: 'direct-client-id', client_secret: 'direct-secret' });
+  });
+
+  it('throws on a file with no recognized format', async () => {
+    vi.mocked(fsPromises.readFile).mockResolvedValueOnce(JSON.stringify({ random: 'stuff' }));
+    await expect(loadCredentials()).rejects.toThrow(/Invalid credentials file format/);
+  });
+});
+
+describe('initializeOAuth2Client redirect_uri extraction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.GOOGLE_OAUTH_CREDENTIALS = FAKE_PATH;
+  });
+
+  afterEach(() => {
+    delete process.env.GOOGLE_OAUTH_CREDENTIALS;
+  });
+
+  it('uses the redirect URI from the "installed" format', async () => {
+    vi.mocked(fsPromises.readFile).mockResolvedValueOnce(JSON.stringify({
+      installed: {
+        client_id: 'cid',
+        client_secret: 'cs',
+        redirect_uris: ['http://localhost:3000/installed-cb'],
+      },
+    }));
+    const client = await initializeOAuth2Client();
+    // google-auth-library stores it on the underlying redirectUri / _redirectUri
+    const ru = (client as any).redirectUri ?? (client as any)._redirectUri;
+    expect(ru).toBe('http://localhost:3000/installed-cb');
+  });
+
+  it('uses the redirect URI from the "web" format', async () => {
+    vi.mocked(fsPromises.readFile).mockResolvedValueOnce(JSON.stringify({
+      web: {
+        client_id: 'cid',
+        client_secret: 'cs',
+        redirect_uris: ['https://oauth.example.com/web-cb'],
+      },
+    }));
+    const client = await initializeOAuth2Client();
+    const ru = (client as any).redirectUri ?? (client as any)._redirectUri;
+    expect(ru).toBe('https://oauth.example.com/web-cb');
+  });
+});
+
+describe('getCredentialsProjectId', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.GOOGLE_OAUTH_CREDENTIALS = FAKE_PATH;
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    delete process.env.GOOGLE_OAUTH_CREDENTIALS;
+  });
+
+  it('reads project_id from the "installed" format', () => {
+    vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({
+      installed: { project_id: 'desktop-project' },
+    }));
+    expect(getCredentialsProjectId()).toBe('desktop-project');
+  });
+
+  it('reads project_id from the "web" format', () => {
+    vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({
+      web: { project_id: 'web-project' },
+    }));
+    expect(getCredentialsProjectId()).toBe('web-project');
+  });
+
+  it('reads project_id from the direct (root-level) format', () => {
+    vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({
+      project_id: 'direct-project',
+    }));
+    expect(getCredentialsProjectId()).toBe('direct-project');
+  });
+
+  it('returns undefined when no project_id is present', () => {
+    vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({
+      web: { client_id: 'cid' },
+    }));
+    expect(getCredentialsProjectId()).toBeUndefined();
+  });
+
+  it('returns undefined when the credentials file does not exist', () => {
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+    expect(getCredentialsProjectId()).toBeUndefined();
+  });
+});


### PR DESCRIPTION
> 🤖 **Disclosure**: This PR was developed with the help of an AI assistant
> (Claude Code). All code, tests, and PR description have been reviewed by
> a human contributor before submission.

## Summary

`loadCredentialsFromFile()` currently accepts OAuth credentials in
`{"installed": {...}}` (Desktop) or root-level format, but throws on the
`{"web": {...}}` format produced by Google Cloud Console when the OAuth
client is created as type "Web application". This PR adds support for the
`web` format and extends `getCredentialsProjectId()` accordingly.

## Why this matters

The `web` format is produced when the OAuth 2.0 Client ID is registered
with a public HTTPS redirect URI — typical when running an OAuth proxy /
bridge that mediates auth for multiple end users behind a centralized
callback URL (rather than each user authenticating from their own machine
via a localhost redirect).

In that setup, the current behaviour is confusing: the MCP starts without
crashing because the credentials error bubbles up only when an OAuth
client is needed, then surfaces as `unauthorized_client` from Google at
refresh time (the refresh request is sent with `client_id=undefined`).

## Changes

- `src/auth/client.ts`: add `else if (keys.web)` branch in
  `loadCredentialsFromFile`, mirroring the existing `installed` one.
  Updated the final error message to mention the `web` option.
- `src/auth/utils.ts`: extend `OAuthCredentialsWithProject` interface and
  add `web.project_id` extraction in `getCredentialsProjectId`.

## Tests

Adds `src/tests/unit/auth/client.test.ts` (11 tests) that **also covers
the existing untested code paths**:

- `loadCredentials` returns client_id/client_secret for **all three**
  formats (`installed` / `web` / root-level).
- `loadCredentials` throws "Invalid credentials file format" on
  unrecognized files.
- `initializeOAuth2Client` surfaces the redirect URI from `installed`
  and `web` formats.
- `getCredentialsProjectId` reads `project_id` from all three formats
  and returns `undefined` when missing or when the credentials file
  does not exist.

Test files: 49 → 50 ; tests: 819 → 830, all passing locally.

## Backward compatibility

None of the existing branches change behaviour. Files that don't contain
a `web` key fall through to the `client_id`/`client_secret` root branch
or to the existing error — exactly as before.
