### PR TITLE
feat: add delete-calendar tool

### DIFF
--- a/src/handlers/core/DeleteCalendarHandler.ts
+++ b/src/handlers/core/DeleteCalendarHandler.ts
@@ -1,0 +1,44 @@
+import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { OAuth2Client } from "google-auth-library";
+import { BaseToolHandler } from "./BaseToolHandler.js";
+import { DeleteCalendarInput } from "../../tools/registry.js";
+import { DeleteCalendarResponse } from "../../types/structured-responses.js";
+import { createStructuredResponse } from "../../utils/response-builder.js";
+
+export class DeleteCalendarHandler extends BaseToolHandler {
+    async runTool(args: any, accounts: Map<string, OAuth2Client>): Promise<CallToolResult> {
+        const validArgs = args as DeleteCalendarInput;
+
+        // Get OAuth2Client with automatic account selection for write operations
+        // Also resolves calendar name to ID if a name was provided
+        const { client: oauth2Client, calendarId: resolvedCalendarId } = await this.getClientWithAutoSelection(
+            args.account,
+            validArgs.calendarId,
+            accounts,
+            'write'
+        );
+
+        // Delete (unsubscribe from) the calendar with resolved calendar ID
+        await this.deleteCalendar(oauth2Client, resolvedCalendarId);
+
+        const response: DeleteCalendarResponse = {
+            success: true,
+            calendarId: resolvedCalendarId,
+            message: "Calendar deleted successfully"
+        };
+
+        return createStructuredResponse(response);
+    }
+
+    private async deleteCalendar(
+        client: OAuth2Client,
+        calendarId: string
+    ): Promise<void> {
+        try {
+            const calendar = this.getCalendar(client);
+            await calendar.calendarList.delete({ calendarId });
+        } catch (error) {
+            throw this.handleGoogleApiError(error);
+        }
+    }
+}

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -18,6 +18,7 @@ import { DeleteEventHandler } from "../handlers/core/DeleteEventHandler.js";
 import { FreeBusyEventHandler } from "../handlers/core/FreeBusyEventHandler.js";
 import { GetCurrentTimeHandler } from "../handlers/core/GetCurrentTimeHandler.js";
 import { RespondToEventHandler } from "../handlers/core/RespondToEventHandler.js";
+import { DeleteCalendarHandler } from "../handlers/core/DeleteCalendarHandler.js";
 
 // ============================================================================
 // SHARED VALIDATION PATTERNS
@@ -684,6 +685,11 @@ export const ToolSchemas = {
     )
   }),
 
+  'delete-calendar': z.object({
+    account: singleAccountSchema,
+    calendarId: z.string().describe("ID of the calendar to delete/unsubscribe from")
+  }),
+
   'get-freebusy': z.object({
     account: multiAccountSchema.describe(
       "Account nickname(s) to query (e.g., 'work' or ['work', 'personal']). Omit to query all accounts."
@@ -767,6 +773,7 @@ export type CreateEventInput = ToolInputs['create-event'];
 export type CreateEventsInput = ToolInputs['create-events'];
 export type UpdateEventInput = ToolInputs['update-event'];
 export type DeleteEventInput = ToolInputs['delete-event'];
+export type DeleteCalendarInput = ToolInputs['delete-calendar'];
 export type GetFreeBusyInput = ToolInputs['get-freebusy'];
 export type GetCurrentTimeInput = ToolInputs['get-current-time'];
 export type RespondToEventInput = ToolInputs['respond-to-event'];
@@ -960,6 +967,14 @@ export class ToolRegistry {
       annotations: WRITE_DESTRUCTIVE_ANNOTATIONS,
       schema: ToolSchemas['delete-event'],
       handler: DeleteEventHandler
+    },
+    {
+      name: "delete-calendar",
+      title: "Delete Calendar",
+      description: "Delete (unsubscribe from) a calendar. Removes it from the calendar list. For owned calendars this permanently deletes the calendar and all its events.",
+      annotations: WRITE_DESTRUCTIVE_ANNOTATIONS,
+      schema: ToolSchemas['delete-calendar'],
+      handler: DeleteCalendarHandler
     },
     {
       name: "get-freebusy",

--- a/src/types/structured-responses.ts
+++ b/src/types/structured-responses.ts
@@ -306,6 +306,15 @@ export interface DeleteEventResponse {
 }
 
 /**
+ * Response format for deleting (unsubscribing from) a calendar
+ */
+export interface DeleteCalendarResponse {
+  success: boolean;
+  calendarId: string;
+  message?: string;
+}
+
+/**
  * Response format for responding to an event invitation
  */
 export interface RespondToEventResponse {


### PR DESCRIPTION
## Summary

Adds a `delete-calendar` MCP tool that allows agents to delete or unsubscribe from a Google Calendar.

## New Tool: `delete-calendar`

**Parameters:**
- `calendarId` (required): ID of the calendar to delete/unsubscribe from
- `account` (optional): Account nickname for multi-account setups

**Behavior:**
- For calendars owned by the user: permanently deletes the calendar and all its events
- For subscribed calendars: unsubscribes (removes from list)
- Returns a success confirmation with the deleted calendar ID

## Motivation

The existing MCP only supports deleting individual events (`delete-event`). There is no way to remove a calendar entirely, which is a common administrative operation.

## Implementation

Follows the exact same handler/schema/registry pattern as the existing `DeleteEventHandler`.