### PR TITLE
Support remote OAuth callbacks and request-scoped HTTP auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 node_modules/
 build/
 *.log
-gcp-oauth.keys.json
+gcp-oauth.keys*.json
 .gcp-saved-tokens.json
 coverage/
 .nyc_output/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,13 +42,25 @@ services:
     
     # Health check for HTTP mode (safe for stdio mode too)
     healthcheck:
-      test: ["CMD-SHELL", "if [ \"$TRANSPORT\" = \"http\" ]; then curl -f http://localhost:${PORT:-3000}/health || exit 1; else exit 0; fi"]
+      test: ["CMD", "node", "-e", "if (process.env.TRANSPORT && process.env.TRANSPORT !== 'http') process.exit(0); fetch('http://127.0.0.1:' + (process.env.PORT || '3000') + '/health').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1));"]
       interval: 30s
       timeout: 10s
       retries: 3
       start_period: 40s
 
+    networks:
+      default:
+      litellm_shared:
+        aliases:
+          - integrahub-calendar-mcp
+          - calendar-mcp
+
 # Persistent volume for OAuth tokens
 volumes:
   calendar-tokens:
     driver: local
+
+networks:
+  litellm_shared:
+    external: true
+    name: litellm_litellm_network

--- a/scripts/check-imports.js
+++ b/scripts/check-imports.js
@@ -25,7 +25,8 @@ const builtins = new Set([
   'util', 'events', 'buffer', 'querystring', 'net', 'child_process',
   'fs/promises', 'node:fs', 'node:path', 'node:url', 'node:crypto',
   'node:child_process', 'node:http', 'node:https', 'node:os', 'node:stream',
-  'node:util', 'node:events', 'node:buffer', 'node:querystring', 'node:net'
+  'node:util', 'node:events', 'node:buffer', 'node:querystring', 'node:net',
+  'node:async_hooks'
 ]);
 
 // Find all .ts files in src/

--- a/src/auth/client.ts
+++ b/src/auth/client.ts
@@ -7,9 +7,17 @@ async function loadCredentialsFromFile(): Promise<OAuthCredentials> {
   const keys = JSON.parse(keysContent);
 
   if (keys.installed) {
-    // Standard OAuth credentials file format
+    // Standard OAuth credentials file format (desktop app)
     const { client_id, client_secret, redirect_uris } = keys.installed;
     return { client_id, client_secret, redirect_uris };
+  } else if (keys.web) {
+    // Standard OAuth credentials file format (web app)
+    const { client_id, client_secret, redirect_uris } = keys.web;
+    return {
+      client_id,
+      client_secret,
+      redirect_uris: redirect_uris || ['http://localhost:3000/oauth2callback']
+    };
   } else if (keys.client_id && keys.client_secret) {
     // Direct format
     return {
@@ -18,7 +26,7 @@ async function loadCredentialsFromFile(): Promise<OAuthCredentials> {
       redirect_uris: keys.redirect_uris || ['http://localhost:3000/oauth2callback']
     };
   } else {
-    throw new Error('Invalid credentials file format. Expected either "installed" object or direct client_id/client_secret fields.');
+    throw new Error('Invalid credentials file format. Expected "installed", "web", or direct client_id/client_secret fields.');
   }
 }
 

--- a/src/auth/redirectUri.ts
+++ b/src/auth/redirectUri.ts
@@ -1,0 +1,30 @@
+export interface OAuthRedirectUriOptions {
+  defaultHost: string;
+  runtimePort: number;
+  query?: string;
+}
+
+/**
+ * Builds the OAuth callback URI used by Google.
+ *
+ * HTTPS callbacks omit the port by default, while local HTTP callbacks retain
+ * the runtime listener port. GOOGLE_OAUTH_REDIRECT_PORT can override either
+ * behavior when a reverse proxy exposes a non-standard external port.
+ */
+export function buildOAuthRedirectUri({
+  defaultHost,
+  runtimePort,
+  query = ''
+}: OAuthRedirectUriOptions): string {
+  const redirectHost = process.env.GOOGLE_OAUTH_REDIRECT_HOST || defaultHost;
+  const redirectScheme =
+    String(process.env.GOOGLE_OAUTH_REDIRECT_SCHEME || 'http').toLowerCase() === 'https'
+      ? 'https'
+      : 'http';
+  const configuredRedirectPort = String(process.env.GOOGLE_OAUTH_REDIRECT_PORT || '').trim();
+  const effectivePort = configuredRedirectPort || String(runtimePort);
+  const includePort = configuredRedirectPort.length > 0 || redirectScheme !== 'https';
+  const portSegment = includePort ? `:${effectivePort}` : '';
+
+  return `${redirectScheme}://${redirectHost}${portSegment}/oauth2callback${query}`;
+}

--- a/src/auth/requestContext.ts
+++ b/src/auth/requestContext.ts
@@ -1,0 +1,28 @@
+import { AsyncLocalStorage } from 'async_hooks';
+
+export interface RequestAuthContext {
+  accessToken?: string;
+}
+
+const requestAuthContextStorage = new AsyncLocalStorage<RequestAuthContext>();
+
+export function runWithRequestAuthContext<T>(
+  context: RequestAuthContext,
+  fn: () => T
+): T {
+  return requestAuthContextStorage.run(context, fn);
+}
+
+export function getRequestAuthContext(): RequestAuthContext | undefined {
+  return requestAuthContextStorage.getStore();
+}
+
+export function getRequestAccessToken(): string | undefined {
+  const accessToken = getRequestAuthContext()?.accessToken;
+  if (!accessToken) {
+    return undefined;
+  }
+
+  const trimmed = accessToken.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}

--- a/src/auth/requestContext.ts
+++ b/src/auth/requestContext.ts
@@ -1,4 +1,4 @@
-import { AsyncLocalStorage } from 'async_hooks';
+import { AsyncLocalStorage } from 'node:async_hooks';
 
 export interface RequestAuthContext {
   accessToken?: string;

--- a/src/auth/server.ts
+++ b/src/auth/server.ts
@@ -6,6 +6,7 @@ import { URL } from 'url';
 import open from 'open';
 import { loadCredentials } from './client.js';
 import { getAccountMode } from './utils.js';
+import { buildOAuthRedirectUri } from './redirectUri.js';
 import { renderAuthSuccess, renderAuthError, renderAuthLanding, loadWebFile } from '../web/templates.js';
 
 export interface StartForMcpToolResult {
@@ -47,7 +48,7 @@ export class AuthServer {
     return new OAuth2Client(
       client_id,
       client_secret,
-      `http://localhost:${port}/oauth2callback`
+      buildOAuthRedirectUri({ defaultHost: 'localhost', runtimePort: port })
     );
   }
 
@@ -415,7 +416,7 @@ export class AuthServer {
     return {
       success: true,
       authUrl,
-      callbackUrl: `http://localhost:${port}/oauth2callback`
+      callbackUrl: buildOAuthRedirectUri({ defaultHost: 'localhost', runtimePort: port })
     };
   }
-} 
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -21,6 +21,9 @@ import { z } from 'zod';
 import { StdioTransportHandler } from './transports/stdio.js';
 import { HttpTransportHandler, HttpTransportConfig } from './transports/http.js';
 
+// Import request auth context for per-request OAuth passthrough
+import { getRequestAccessToken } from './auth/requestContext.js';
+
 // Import config
 import { ServerConfig } from './config/TransportConfig.js';
 
@@ -196,6 +199,20 @@ export class GoogleCalendarMcpServer {
   }
 
   private async executeWithHandler(handler: any, args: any): Promise<{ content: Array<{ type: "text"; text: string }> }> {
+    const requestAccessToken = getRequestAccessToken();
+
+    // In HTTP mode, allow per-request OAuth bearer token passthrough (e.g., via LiteLLM-managed user OAuth).
+    // This avoids requiring shared local token storage for every user.
+    if (requestAccessToken && this.config.transport.type === 'http') {
+      const requestScopedAccounts = new Map<string, OAuth2Client>();
+      const oauthPassthroughClient = new OAuth2Client();
+      oauthPassthroughClient.setCredentials({ access_token: requestAccessToken });
+      requestScopedAccounts.set('oauth_passthrough', oauthPassthroughClient);
+
+      const result = await handler.runTool(args, requestScopedAccounts);
+      return result;
+    }
+
     await this.ensureAuthenticated();
 
     const result = await handler.runTool(args, this.accounts);

--- a/src/tests/unit/auth/AuthServer.test.ts
+++ b/src/tests/unit/auth/AuthServer.test.ts
@@ -62,6 +62,9 @@ describe('AuthServer', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     vi.useFakeTimers();
+    vi.stubEnv('GOOGLE_OAUTH_REDIRECT_HOST', '');
+    vi.stubEnv('GOOGLE_OAUTH_REDIRECT_SCHEME', '');
+    vi.stubEnv('GOOGLE_OAUTH_REDIRECT_PORT', '');
 
     // Create mock OAuth2Client
     mockOAuth2Client = new OAuth2Client('client-id', 'client-secret', 'redirect-uri');
@@ -87,6 +90,7 @@ describe('AuthServer', () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    vi.unstubAllEnvs();
     vi.resetModules();
   });
 

--- a/src/tests/unit/auth/redirectUri.test.ts
+++ b/src/tests/unit/auth/redirectUri.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { buildOAuthRedirectUri } from '../../../auth/redirectUri.js';
+
+describe('buildOAuthRedirectUri', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('uses the runtime port for a local HTTP callback', () => {
+    vi.stubEnv('GOOGLE_OAUTH_REDIRECT_HOST', '');
+    vi.stubEnv('GOOGLE_OAUTH_REDIRECT_SCHEME', '');
+    vi.stubEnv('GOOGLE_OAUTH_REDIRECT_PORT', '');
+
+    expect(buildOAuthRedirectUri({
+      defaultHost: 'localhost',
+      runtimePort: 3500
+    })).toBe('http://localhost:3500/oauth2callback');
+  });
+
+  it('omits the default port for an external HTTPS callback', () => {
+    vi.stubEnv('GOOGLE_OAUTH_REDIRECT_HOST', 'calendar.example.com');
+    vi.stubEnv('GOOGLE_OAUTH_REDIRECT_SCHEME', 'https');
+    vi.stubEnv('GOOGLE_OAUTH_REDIRECT_PORT', '');
+
+    expect(buildOAuthRedirectUri({
+      defaultHost: 'localhost',
+      runtimePort: 3500
+    })).toBe('https://calendar.example.com/oauth2callback');
+  });
+
+  it('uses an explicitly configured external port and preserves the query', () => {
+    vi.stubEnv('GOOGLE_OAUTH_REDIRECT_HOST', 'calendar.example.com');
+    vi.stubEnv('GOOGLE_OAUTH_REDIRECT_SCHEME', 'https');
+    vi.stubEnv('GOOGLE_OAUTH_REDIRECT_PORT', '8443');
+
+    expect(buildOAuthRedirectUri({
+      defaultHost: 'localhost',
+      runtimePort: 3500,
+      query: '?account=work'
+    })).toBe('https://calendar.example.com:8443/oauth2callback?account=work');
+  });
+});

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -5,6 +5,7 @@ import { TokenManager } from "../auth/tokenManager.js";
 import { CalendarRegistry } from "../services/CalendarRegistry.js";
 import { renderAuthSuccess, renderAuthError, loadWebFile } from "../web/templates.js";
 import { runWithRequestAuthContext } from "../auth/requestContext.js";
+import { buildOAuthRedirectUri } from "../auth/redirectUri.js";
 
 /**
  * Security headers for HTML responses
@@ -65,11 +66,14 @@ export class HttpTransportHandler {
     const { OAuth2Client } = await import('google-auth-library');
     const { loadCredentials } = await import('../auth/client.js');
     const { client_id, client_secret } = await loadCredentials();
-    const redirectHost = process.env.GOOGLE_OAUTH_REDIRECT_HOST || (host === "0.0.0.0" ? "localhost" : host);
     return new OAuth2Client(
       client_id,
       client_secret,
-      `http://${redirectHost}:${port}/oauth2callback?account=${accountId}`
+      buildOAuthRedirectUri({
+        defaultHost: host === "0.0.0.0" ? "localhost" : host,
+        runtimePort: port,
+        query: `?account=${accountId}`
+      })
     );
   }
 

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -4,6 +4,7 @@ import http from "http";
 import { TokenManager } from "../auth/tokenManager.js";
 import { CalendarRegistry } from "../services/CalendarRegistry.js";
 import { renderAuthSuccess, renderAuthError, loadWebFile } from "../web/templates.js";
+import { runWithRequestAuthContext } from "../auth/requestContext.js";
 
 /**
  * Security headers for HTML responses
@@ -64,10 +65,11 @@ export class HttpTransportHandler {
     const { OAuth2Client } = await import('google-auth-library');
     const { loadCredentials } = await import('../auth/client.js');
     const { client_id, client_secret } = await loadCredentials();
+    const redirectHost = process.env.GOOGLE_OAUTH_REDIRECT_HOST || (host === "0.0.0.0" ? "localhost" : host);
     return new OAuth2Client(
       client_id,
       client_secret,
-      `http://${host}:${port}/oauth2callback?account=${accountId}`
+      `http://${redirectHost}:${port}/oauth2callback?account=${accountId}`
     );
   }
 
@@ -91,6 +93,28 @@ export class HttpTransportHandler {
     validateAccountId(accountId);
   }
 
+  private extractBearerToken(authorizationHeader: string | string[] | undefined): string | undefined {
+    if (!authorizationHeader) {
+      return undefined;
+    }
+
+    const headerValue = Array.isArray(authorizationHeader)
+      ? authorizationHeader[0]
+      : authorizationHeader;
+
+    if (!headerValue) {
+      return undefined;
+    }
+
+    const match = headerValue.match(/^Bearer\s+(.+)$/i);
+    if (!match || !match[1]) {
+      return undefined;
+    }
+
+    const token = match[1].trim();
+    return token.length > 0 ? token : undefined;
+  }
+
   private parseRequestBody(req: http.IncomingMessage): Promise<any> {
     return new Promise((resolve, reject) => {
       let body = '';
@@ -110,9 +134,10 @@ export class HttpTransportHandler {
     const port = this.config.port || 3000;
     const host = this.config.host || '127.0.0.1';
 
-    // Configure transport for stateless mode to allow multiple initialization cycles
+    // Use stateless mode for compatibility with clients that re-initialize frequently (e.g. LiteLLM).
+    // The SDK forbids reusing a stateless transport instance unless _hasHandledRequest is reset.
     const transport = new StreamableHTTPServerTransport({
-      sessionIdGenerator: undefined // Stateless mode - allows multiple initializations
+      sessionIdGenerator: undefined
     });
 
     await this.server.connect(transport);
@@ -170,6 +195,12 @@ export class HttpTransportHandler {
             message: 'Accept header must include application/json or text/event-stream'
           }));
           return;
+        }
+
+        // Streamable HTTP MCP requires clients to accept both application/json and text/event-stream.
+        // Some clients only send one; normalize here to improve interoperability.
+        if (!acceptHeader || !acceptHeader.includes('application/json') || !acceptHeader.includes('text/event-stream')) {
+          req.headers.accept = 'application/json, text/event-stream';
         }
       }
 
@@ -421,7 +452,14 @@ export class HttpTransportHandler {
       }
 
       try {
-        await transport.handleRequest(req, res);
+        // Reset internal stateless guard so this transport can accept a new request cycle.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (transport as any)._webStandardTransport._hasHandledRequest = false;
+
+        const accessToken = this.extractBearerToken(req.headers.authorization);
+        await runWithRequestAuthContext({ accessToken }, async () => {
+          await transport.handleRequest(req, res);
+        });
       } catch (error) {
         process.stderr.write(`Error handling request: ${error instanceof Error ? error.message : error}\n`);
         if (!res.headersSent) {


### PR DESCRIPTION
## Summary
- support installed, web, and direct Google OAuth credential formats
- propagate bearer tokens through request-scoped HTTP transport context
- support configurable external OAuth callback hosts, schemes, and ports
- centralize callback URI construction and add focused coverage
- harden local OAuth credential backup ignore rules and Node built-in import validation
- connect the deployment to the shared LiteLLM network and improve its health check

## Validation
- `npm run build`
- `npm run lint`
- `npm test -- --reporter=dot` (50 files, 812 tests)
- `npm run check:imports`
- `git diff --check`

Conversation: https://app.warp.dev/conversation/3c637b05-79bd-4c0a-8334-ff36d48c700c

Co-Authored-By: Oz <oz-agent@warp.dev>