### PR TITLE
fix(http): use per-session StreamableHTTP transports

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "test:integration:openai": "npm run build && vitest run src/tests/integration/openai-mcp-integration.test.ts",
     "test:integration:llm": "npm run test:integration:claude && npm run test:integration:openai",
     "test:integration:docker": "npm run build && vitest run src/tests/integration/docker-integration.test.ts",
+    "test:integration:http": "npm run build && vitest run src/tests/integration/http-transport.test.ts",
     "test:integration:all": "npm run build && vitest run src/tests/integration",
     "test:all": "npm run test && npm run test:integration:all",
     "test:coverage": "vitest run src/tests/unit --coverage",

--- a/src/server.ts
+++ b/src/server.ts
@@ -31,7 +31,7 @@ const __server_dirname = dirname(fileURLToPath(import.meta.url));
 const SERVER_VERSION = JSON.parse(readFileSync(join(__server_dirname, '..', 'package.json'), 'utf-8')).version;
 
 export class GoogleCalendarMcpServer {
-  private server: McpServer;
+  private server!: McpServer;
   private oauth2Client!: OAuth2Client;
   private tokenManager!: TokenManager;
   private authServer!: AuthServer;
@@ -40,10 +40,6 @@ export class GoogleCalendarMcpServer {
 
   constructor(config: ServerConfig) {
     this.config = config;
-    this.server = new McpServer({
-      name: "google-calendar",
-      version: SERVER_VERSION
-    });
   }
 
   async initialize(): Promise<void> {

--- a/src/server.ts
+++ b/src/server.ts
@@ -59,9 +59,7 @@ export class GoogleCalendarMcpServer {
     await this.handleStartupAuthentication();
 
     // 4. Set up Modern Tool Definitions
-    this.registerTools();
-    this.registerPrompts();
-    this.registerResources();
+    this.server = this.buildServer();
 
     // 5. Set up Graceful Shutdown
     this.setupGracefulShutdown();
@@ -109,11 +107,22 @@ export class GoogleCalendarMcpServer {
     }
   }
 
-  private registerTools(): void {
-    ToolRegistry.registerAll(this.server, this.executeWithHandler.bind(this), this.config);
+  private buildServer(): McpServer {
+    const server = new McpServer({
+      name: "google-calendar",
+      version: SERVER_VERSION
+    });
+    this.registerTools(server);
+    this.registerPrompts(server);
+    this.registerResources(server);
+    return server;
+  }
+
+  private registerTools(server: McpServer): void {
+    ToolRegistry.registerAll(server, this.executeWithHandler.bind(this), this.config);
 
     // Register account management tools separately (they need special context)
-    this.registerAccountManagementTools();
+    this.registerAccountManagementTools(server);
   }
 
   /**
@@ -122,7 +131,7 @@ export class GoogleCalendarMcpServer {
    * - Doesn't require existing authentication (for 'add' action)
    * - Needs access to authServer, tokenManager, etc.
    */
-  private registerAccountManagementTools(): void {
+  private registerAccountManagementTools(server: McpServer): void {
     // Use arrow functions to keep `this` reference current after reloadAccounts()
     const self = this;
     const serverContext: ServerContext = {
@@ -137,7 +146,7 @@ export class GoogleCalendarMcpServer {
     };
 
     const manageAccountsHandler = new ManageAccountsHandler();
-    this.server.registerTool(
+    server.registerTool(
       'manage-accounts',
       {
         title: 'Manage Google Accounts',
@@ -163,8 +172,8 @@ export class GoogleCalendarMcpServer {
     );
   }
 
-  private registerPrompts(): void {
-    this.server.registerPrompt(
+  private registerPrompts(server: McpServer): void {
+    server.registerPrompt(
       'daily-agenda-brief',
       {
         title: 'Daily Agenda Brief',
@@ -215,7 +224,7 @@ export class GoogleCalendarMcpServer {
       }
     );
 
-    this.server.registerPrompt(
+    server.registerPrompt(
       'find-and-book-meeting',
       {
         title: 'Find and Book Meeting',
@@ -275,8 +284,8 @@ export class GoogleCalendarMcpServer {
     );
   }
 
-  private registerResources(): void {
-    this.server.registerResource(
+  private registerResources(server: McpServer): void {
+    server.registerResource(
       'calendar-accounts',
       'calendar://accounts',
       {
@@ -400,7 +409,7 @@ export class GoogleCalendarMcpServer {
           host: this.config.transport.host
         };
         const httpHandler = new HttpTransportHandler(
-          this.server,
+          () => this.buildServer(),
           httpConfig,
           this.tokenManager
         );

--- a/src/tests/integration/http-transport.test.ts
+++ b/src/tests/integration/http-transport.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawn, ChildProcess } from 'node:child_process';
+import { createServer } from 'node:net';
+import { writeFileSync, rmSync, mkdtempSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+
+/**
+ * HTTP transport handshake integration test.
+ *
+ * Proves the per-session StreamableHTTP fix: two clients each complete the full
+ * MCP handshake (initialize -> notifications/initialized -> tools/list) against a
+ * single running server, and a follow-up request on an established client
+ * succeeds (the original bug 500'd on request #2 because a single stateless
+ * transport was reused across requests).
+ *
+ * Self-contained: spawns the built server with NODE_ENV=test and a dummy
+ * GOOGLE_OAUTH_CREDENTIALS file. Tool registration is token-independent, so no
+ * real Google account, tokens, or network access are required.
+ */
+
+const HOST = '127.0.0.1';
+
+function getFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.on('error', reject);
+    srv.listen(0, HOST, () => {
+      const addr = srv.address();
+      const port = typeof addr === 'object' && addr ? addr.port : 0;
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+function startHttpServer(port: number, credentialsPath: string): Promise<ChildProcess> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      'node',
+      ['build/index.js', '--transport', 'http', '--host', HOST, '--port', String(port)],
+      {
+        env: { ...process.env, NODE_ENV: 'test', GOOGLE_OAUTH_CREDENTIALS: credentialsPath },
+        stdio: ['ignore', 'pipe', 'pipe']
+      }
+    );
+
+    let settled = false;
+    const onOutput = (buf: Buffer) => {
+      if (!settled && buf.toString().includes('listening on http')) {
+        settled = true;
+        resolve(child);
+      }
+    };
+    child.stderr.on('data', onOutput);
+    child.stdout.on('data', onOutput);
+    child.on('exit', (code) => {
+      if (!settled) {
+        reject(new Error(`Server exited before it was ready (code ${code})`));
+      }
+    });
+
+    // Failsafe watchdog, not a fixed wait: readiness resolves on the real
+    // "listening" banner above. Fake timers cannot drive a spawned subprocess,
+    // so a real wall-clock guard is required to avoid hanging forever on a
+    // server that never binds.
+
+    setTimeout(() => {
+      if (!settled) {
+        child.kill('SIGKILL');
+        reject(new Error('Server did not become ready within 15s'));
+      }
+    }, 15000);
+  });
+}
+
+async function connectClient(name: string, url: string): Promise<Client> {
+  const client = new Client({ name, version: '1.0.0' }, { capabilities: {} });
+  const transport = new StreamableHTTPClientTransport(new URL(url));
+  await client.connect(transport); // performs initialize + notifications/initialized
+  return client;
+}
+
+describe('HTTP transport - per-session handshake', () => {
+  let server: ChildProcess;
+  let port: number;
+  let tempDir: string;
+  let mcpUrl: string;
+
+  beforeAll(async () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'gcal-mcp-http-'));
+    const credentialsPath = join(tempDir, 'credentials.json');
+    writeFileSync(
+      credentialsPath,
+      JSON.stringify({ client_id: 'test-client-id', client_secret: 'test-client-secret' })
+    );
+
+    port = await getFreePort();
+    mcpUrl = `http://${HOST}:${port}/mcp`;
+    server = await startHttpServer(port, credentialsPath);
+  }, 30000);
+
+  afterAll(() => {
+    if (server && !server.killed) {
+      server.kill('SIGKILL');
+    }
+    if (tempDir) {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('completes the handshake and lists calendar tools (R1)', async () => {
+    const client = await connectClient('http-client-1', mcpUrl);
+    try {
+      const { tools } = await client.listTools();
+      const names = tools.map((t) => t.name);
+      expect(names).toContain('list-events');
+      expect(names).toContain('create-event');
+
+      // Follow-up request on an established session must not 500 (the original bug).
+      const second = await client.listTools();
+      expect(second.tools.length).toBe(tools.length);
+    } finally {
+      await client.close();
+    }
+  }, 30000);
+
+  it('supports two sequential clients, each isolated (R2)', async () => {
+    const clientA = await connectClient('http-client-a', mcpUrl);
+    let namesA: string[];
+    try {
+      namesA = (await clientA.listTools()).tools.map((t) => t.name);
+      expect(namesA).toContain('list-events');
+    } finally {
+      await clientA.close();
+    }
+
+    // A second client connecting after the first proves per-session isolation
+    // rather than one-shot success against a shared transport.
+    const clientB = await connectClient('http-client-b', mcpUrl);
+    try {
+      const namesB = (await clientB.listTools()).tools.map((t) => t.name);
+      expect(namesB).toContain('list-events');
+      expect(namesB).toContain('create-event');
+      expect(namesB.sort()).toEqual(namesA.sort());
+    } finally {
+      await clientB.close();
+    }
+  }, 30000);
+});

--- a/src/tests/unit/server/GoogleCalendarMcpServer.test.ts
+++ b/src/tests/unit/server/GoogleCalendarMcpServer.test.ts
@@ -217,6 +217,9 @@ describe('GoogleCalendarMcpServer', () => {
     const args = (state.httpConnect as any).mockHttpArgs;
     expect(args[1]).toEqual({ host: '0.0.0.0', port: 3456 });
     expect(args[2]).toBe(state.tokenManagerInstance);
+    // U1: the HTTP handler now receives a server *factory*, not a prebuilt server.
+    expect(typeof args[0]).toBe('function');
+    expect(args[0]()).toBe(state.mcpServerInstance);
   });
 
   it('throws for unsupported transport types', async () => {

--- a/src/tests/unit/transports/handlers.test.ts
+++ b/src/tests/unit/transports/handlers.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const state = vi.hoisted(() => ({
   requestHandler: undefined as ((req: any, res: any) => Promise<void>) | undefined,
   transport: undefined as { handleRequest: ReturnType<typeof vi.fn> } | undefined,
+  transports: [] as any[],
   listen: vi.fn(),
   clearCache: vi.fn(),
   renderAuthSuccess: vi.fn(async () => '<html>success</html>'),
@@ -15,9 +16,23 @@ const state = vi.hoisted(() => ({
 
 vi.mock('@modelcontextprotocol/sdk/server/streamableHttp.js', () => ({
   StreamableHTTPServerTransport: class MockStreamableHTTPServerTransport {
-    handleRequest = vi.fn(async () => undefined);
-    constructor() {
+    sessionId: string | undefined = undefined;
+    onclose: (() => void) | undefined = undefined;
+    options: any;
+    handleRequest = vi.fn(async (_req: any, _res: any, body?: any) => {
+      // Simulate the SDK assigning a session id and firing the callback on initialize
+      if (body?.method === 'initialize' && this.options?.sessionIdGenerator) {
+        this.sessionId = this.options.sessionIdGenerator();
+        this.options.onsessioninitialized?.(this.sessionId);
+      }
+    });
+    close = vi.fn(async () => {
+      this.onclose?.();
+    });
+    constructor(options?: any) {
+      this.options = options;
       state.transport = this;
+      state.transports.push(this);
     }
   }
 }));
@@ -115,11 +130,45 @@ async function invokeHandler(req: any, res: any): Promise<void> {
   await handler(req, res);
 }
 
+function makeTokenManager() {
+  return { listAccounts: vi.fn(), getAccountMode: vi.fn(), setAccountMode: vi.fn(), clearTokens: vi.fn(), saveTokens: vi.fn() } as any;
+}
+
+function makeInitializeBody() {
+  return {
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'initialize',
+    params: {
+      protocolVersion: '2025-06-18',
+      capabilities: {},
+      clientInfo: { name: 'test', version: '1.0' }
+    }
+  };
+}
+
+async function postJson(req: any, res: any, body: unknown): Promise<void> {
+  const pending = invokeHandler(req, res);
+  req.emit('data', Buffer.from(JSON.stringify(body)));
+  req.emit('end');
+  await pending;
+}
+
+// Drives a full session-opening initialize POST and returns the created transport + id.
+async function openSession(): Promise<{ transport: any; sessionId: string }> {
+  const req = createMockRequest({ method: 'POST', url: '/', headers: { accept: 'application/json' } });
+  const res = createMockResponse();
+  await postJson(req, res, makeInitializeBody());
+  const transport = state.transport;
+  return { transport, sessionId: transport.sessionId };
+}
+
 describe('Transport Handlers', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     state.requestHandler = undefined;
     state.transport = undefined;
+    state.transports = [];
     state.listen.mockImplementation((_port: number, _host: string, callback?: () => void) => {
       if (callback) {
         callback();
@@ -139,7 +188,7 @@ describe('Transport Handlers', () => {
   it('rejects requests from non-localhost origins', async () => {
     const server = { connect: vi.fn(async () => undefined) } as any;
     const tokenManager = { listAccounts: vi.fn(), getAccountMode: vi.fn(), setAccountMode: vi.fn(), clearTokens: vi.fn(), saveTokens: vi.fn() } as any;
-    const handler = new HttpTransportHandler(server, { port: 3999, host: '127.0.0.1' }, tokenManager);
+    const handler = new HttpTransportHandler(() => server, { port: 3999, host: '127.0.0.1' }, tokenManager);
     await handler.connect();
 
     const req = createMockRequest({
@@ -158,7 +207,7 @@ describe('Transport Handlers', () => {
   it('returns health payload and sets localhost CORS defaults', async () => {
     const server = { connect: vi.fn(async () => undefined) } as any;
     const tokenManager = { listAccounts: vi.fn(), getAccountMode: vi.fn(), setAccountMode: vi.fn(), clearTokens: vi.fn(), saveTokens: vi.fn() } as any;
-    const handler = new HttpTransportHandler(server, { port: 4001, host: '127.0.0.1' }, tokenManager);
+    const handler = new HttpTransportHandler(() => server, { port: 4001, host: '127.0.0.1' }, tokenManager);
     await handler.connect();
 
     const req = createMockRequest({
@@ -184,7 +233,7 @@ describe('Transport Handlers', () => {
       clearTokens: vi.fn(),
       saveTokens: vi.fn()
     } as any;
-    const handler = new HttpTransportHandler(server, {}, tokenManager);
+    const handler = new HttpTransportHandler(() => server, {}, tokenManager);
     await handler.connect();
 
     const req = createMockRequest({
@@ -204,7 +253,7 @@ describe('Transport Handlers', () => {
   it('creates OAuth URL for POST /api/accounts', async () => {
     const server = { connect: vi.fn(async () => undefined) } as any;
     const tokenManager = { listAccounts: vi.fn(), getAccountMode: vi.fn(), setAccountMode: vi.fn(), clearTokens: vi.fn(), saveTokens: vi.fn() } as any;
-    const handler = new HttpTransportHandler(server, { port: 4000, host: 'localhost' }, tokenManager);
+    const handler = new HttpTransportHandler(() => server, { port: 4000, host: 'localhost' }, tokenManager);
     await handler.connect();
 
     const req = createMockRequest({
@@ -226,25 +275,102 @@ describe('Transport Handlers', () => {
     expect(payload.authUrl).toBe('https://auth.example.com');
   });
 
-  it('returns 500 when MCP transport request handling throws', async () => {
+  it('creates a session on initialize and reuses it for follow-up requests', async () => {
     const server = { connect: vi.fn(async () => undefined) } as any;
-    const tokenManager = { listAccounts: vi.fn(), getAccountMode: vi.fn(), setAccountMode: vi.fn(), clearTokens: vi.fn(), saveTokens: vi.fn() } as any;
-    const handler = new HttpTransportHandler(server, {}, tokenManager);
+    const handler = new HttpTransportHandler(() => server, {}, makeTokenManager());
     await handler.connect();
 
-    if (!state.transport) {
-      throw new Error('Transport mock not initialized');
-    }
-    state.transport.handleRequest.mockRejectedValueOnce(new Error('boom'));
+    const { transport, sessionId } = await openSession();
+    expect(sessionId).toBeTruthy();
+    expect(state.transports).toHaveLength(1);
+    expect(server.connect).toHaveBeenCalledTimes(1);
+    expect(transport.handleRequest).toHaveBeenCalledTimes(1);
 
-    const req = createMockRequest({
+    const followReq = createMockRequest({
       method: 'POST',
-      url: '/mcp',
-      headers: { origin: 'http://localhost', accept: 'application/json' }
+      url: '/',
+      headers: { accept: 'application/json', 'mcp-session-id': sessionId }
     });
-    const res = createMockResponse();
+    const followRes = createMockResponse();
+    await postJson(followReq, followRes, { jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} });
 
-    await invokeHandler(req, res);
+    // Reused the same transport; no new transport or server built.
+    expect(state.transports).toHaveLength(1);
+    expect(server.connect).toHaveBeenCalledTimes(1);
+    expect(transport.handleRequest).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects a non-initialize POST without a session id with 400', async () => {
+    const server = { connect: vi.fn(async () => undefined) } as any;
+    const handler = new HttpTransportHandler(() => server, {}, makeTokenManager());
+    await handler.connect();
+
+    const req = createMockRequest({ method: 'POST', url: '/', headers: { accept: 'application/json' } });
+    const res = createMockResponse();
+    await postJson(req, res, { jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toContain('No valid session ID');
+    expect(state.transports).toHaveLength(0);
+  });
+
+  it('rejects GET/DELETE with an unknown session id with 400 (never 500)', async () => {
+    const server = { connect: vi.fn(async () => undefined) } as any;
+    const handler = new HttpTransportHandler(() => server, {}, makeTokenManager());
+    await handler.connect();
+
+    for (const method of ['GET', 'DELETE']) {
+      const req = createMockRequest({ method, url: '/mcp', headers: { accept: 'application/json', 'mcp-session-id': 'unknown' } });
+      const res = createMockResponse();
+      await invokeHandler(req, res);
+      expect(res.statusCode).toBe(400);
+    }
+    expect(state.transports).toHaveLength(0);
+  });
+
+  it('removes a session from the map when the transport closes', async () => {
+    const server = { connect: vi.fn(async () => undefined) } as any;
+    const handler = new HttpTransportHandler(() => server, {}, makeTokenManager());
+    await handler.connect();
+
+    const { transport, sessionId } = await openSession();
+    await transport.close(); // fires onclose -> map delete
+
+    // A follow-up carrying the now-removed id is treated as unknown -> 400.
+    const req = createMockRequest({ method: 'POST', url: '/', headers: { accept: 'application/json', 'mcp-session-id': sessionId } });
+    const res = createMockResponse();
+    await postJson(req, res, { jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toContain('No valid session ID');
+  });
+
+  it('evicts the oldest session when the session cap is exceeded', async () => {
+    const server = { connect: vi.fn(async () => undefined) } as any;
+    const handler = new HttpTransportHandler(() => server, {}, makeTokenManager());
+    await handler.connect();
+
+    const MAX_SESSIONS = 128;
+    for (let i = 0; i < MAX_SESSIONS + 1; i++) {
+      await openSession();
+    }
+
+    expect(state.transports).toHaveLength(MAX_SESSIONS + 1);
+    // The first (oldest) transport was closed/evicted to make room.
+    expect(state.transports[0].close).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns 500 when a mapped transport request handling throws', async () => {
+    const server = { connect: vi.fn(async () => undefined) } as any;
+    const handler = new HttpTransportHandler(() => server, {}, makeTokenManager());
+    await handler.connect();
+
+    const { transport, sessionId } = await openSession();
+    transport.handleRequest.mockRejectedValueOnce(new Error('boom'));
+
+    const req = createMockRequest({ method: 'POST', url: '/', headers: { accept: 'application/json', 'mcp-session-id': sessionId } });
+    const res = createMockResponse();
+    await postJson(req, res, { jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} });
 
     expect(res.statusCode).toBe(500);
     expect(res.body).toContain('Internal server error');

--- a/src/tests/unit/transports/handlers.test.ts
+++ b/src/tests/unit/transports/handlers.test.ts
@@ -316,7 +316,7 @@ describe('Transport Handlers', () => {
     expect(state.transports).toHaveLength(0);
   });
 
-  it('rejects GET/DELETE with an unknown session id with 400 (never 500)', async () => {
+  it('rejects GET/DELETE with an unknown session id with 404/-32001 (never 500)', async () => {
     const server = { connect: vi.fn(async () => undefined) } as any;
     const handler = new HttpTransportHandler(() => server, {}, makeTokenManager());
     await handler.connect();
@@ -325,9 +325,53 @@ describe('Transport Handlers', () => {
       const req = createMockRequest({ method, url: '/mcp', headers: { accept: 'application/json', 'mcp-session-id': 'unknown' } });
       const res = createMockResponse();
       await invokeHandler(req, res);
-      expect(res.statusCode).toBe(400);
+      expect(res.statusCode).toBe(404);
+      expect(JSON.parse(res.body).error.code).toBe(-32001);
     }
     expect(state.transports).toHaveLength(0);
+  });
+
+  it('rejects GET/DELETE with no session id with 400/-32000', async () => {
+    const server = { connect: vi.fn(async () => undefined) } as any;
+    const handler = new HttpTransportHandler(() => server, {}, makeTokenManager());
+    await handler.connect();
+
+    for (const method of ['GET', 'DELETE']) {
+      const req = createMockRequest({ method, url: '/mcp', headers: { accept: 'application/json' } });
+      const res = createMockResponse();
+      await invokeHandler(req, res);
+      expect(res.statusCode).toBe(400);
+      expect(JSON.parse(res.body).error.code).toBe(-32000);
+    }
+  });
+
+  it('returns 404/-32001 for a POST carrying an unknown session id', async () => {
+    const server = { connect: vi.fn(async () => undefined) } as any;
+    const handler = new HttpTransportHandler(() => server, {}, makeTokenManager());
+    await handler.connect();
+
+    const req = createMockRequest({ method: 'POST', url: '/', headers: { accept: 'application/json', 'mcp-session-id': 'bogus' } });
+    const res = createMockResponse();
+    await postJson(req, res, { jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} });
+
+    expect(res.statusCode).toBe(404);
+    expect(JSON.parse(res.body).error.code).toBe(-32001);
+  });
+
+  it('returns 400/-32700 for a malformed JSON body, never 500', async () => {
+    const server = { connect: vi.fn(async () => undefined) } as any;
+    const handler = new HttpTransportHandler(() => server, {}, makeTokenManager());
+    await handler.connect();
+
+    const req = createMockRequest({ method: 'POST', url: '/', headers: { accept: 'application/json' } });
+    const res = createMockResponse();
+    const pending = invokeHandler(req, res);
+    req.emit('data', Buffer.from('{not valid json'));
+    req.emit('end');
+    await pending;
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error.code).toBe(-32700);
   });
 
   it('removes a session from the map when the transport closes', async () => {
@@ -338,28 +382,39 @@ describe('Transport Handlers', () => {
     const { transport, sessionId } = await openSession();
     await transport.close(); // fires onclose -> map delete
 
-    // A follow-up carrying the now-removed id is treated as unknown -> 400.
+    // A follow-up carrying the now-removed id is treated as unknown -> 404.
     const req = createMockRequest({ method: 'POST', url: '/', headers: { accept: 'application/json', 'mcp-session-id': sessionId } });
     const res = createMockResponse();
     await postJson(req, res, { jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} });
 
-    expect(res.statusCode).toBe(400);
-    expect(res.body).toContain('No valid session ID');
+    expect(res.statusCode).toBe(404);
+    expect(JSON.parse(res.body).error.code).toBe(-32001);
   });
 
-  it('evicts the oldest session when the session cap is exceeded', async () => {
+  it('evicts the least-recently-used session, sparing recently-touched ones', async () => {
     const server = { connect: vi.fn(async () => undefined) } as any;
     const handler = new HttpTransportHandler(() => server, {}, makeTokenManager());
     await handler.connect();
 
     const MAX_SESSIONS = 128;
-    for (let i = 0; i < MAX_SESSIONS + 1; i++) {
-      await openSession();
+    const sessions: Array<Awaited<ReturnType<typeof openSession>>> = [];
+    for (let i = 0; i < MAX_SESSIONS; i++) {
+      sessions.push(await openSession());
     }
+    expect(state.transports).toHaveLength(MAX_SESSIONS);
 
-    expect(state.transports).toHaveLength(MAX_SESSIONS + 1);
-    // The first (oldest) transport was closed/evicted to make room.
-    expect(state.transports[0].close).toHaveBeenCalledTimes(1);
+    // Touch the oldest-created session so it becomes most-recently-used.
+    const oldest = sessions[0];
+    const touchReq = createMockRequest({ method: 'POST', url: '/', headers: { accept: 'application/json', 'mcp-session-id': oldest.sessionId } });
+    const touchRes = createMockResponse();
+    await postJson(touchReq, touchRes, { jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} });
+
+    // Open one more session at capacity -> LRU eviction fires.
+    await openSession();
+
+    // The touched oldest session survives; the now-LRU (second-created) is evicted.
+    expect(oldest.transport.close).not.toHaveBeenCalled();
+    expect(sessions[1].transport.close).toHaveBeenCalledTimes(1);
   });
 
   it('returns 500 when a mapped transport request handling throws', async () => {

--- a/src/tests/unit/transports/handlers.test.ts
+++ b/src/tests/unit/transports/handlers.test.ts
@@ -5,6 +5,7 @@ const state = vi.hoisted(() => ({
   requestHandler: undefined as ((req: any, res: any) => Promise<void>) | undefined,
   transport: undefined as { handleRequest: ReturnType<typeof vi.fn> } | undefined,
   transports: [] as any[],
+  suppressSessionInit: false,
   listen: vi.fn(),
   clearCache: vi.fn(),
   renderAuthSuccess: vi.fn(async () => '<html>success</html>'),
@@ -21,7 +22,7 @@ vi.mock('@modelcontextprotocol/sdk/server/streamableHttp.js', () => ({
     options: any;
     handleRequest = vi.fn(async (_req: any, _res: any, body?: any) => {
       // Simulate the SDK assigning a session id and firing the callback on initialize
-      if (body?.method === 'initialize' && this.options?.sessionIdGenerator) {
+      if (!state.suppressSessionInit && body?.method === 'initialize' && this.options?.sessionIdGenerator) {
         this.sessionId = this.options.sessionIdGenerator();
         this.options.onsessioninitialized?.(this.sessionId);
       }
@@ -169,6 +170,7 @@ describe('Transport Handlers', () => {
     state.requestHandler = undefined;
     state.transport = undefined;
     state.transports = [];
+    state.suppressSessionInit = false;
     state.listen.mockImplementation((_port: number, _host: string, callback?: () => void) => {
       if (callback) {
         callback();
@@ -374,5 +376,24 @@ describe('Transport Handlers', () => {
 
     expect(res.statusCode).toBe(500);
     expect(res.body).toContain('Internal server error');
+  });
+
+  it('closes an initialize transport whose handshake never commits a session id', async () => {
+    const server = { connect: vi.fn(async () => undefined) } as any;
+    const handler = new HttpTransportHandler(() => server, {}, makeTokenManager());
+    await handler.connect();
+
+    // Simulate an initialize whose handshake never assigns a session id (aborted).
+    state.suppressSessionInit = true;
+
+    const req = createMockRequest({ method: 'POST', url: '/', headers: { accept: 'application/json' } });
+    const res = createMockResponse();
+    await postJson(req, res, makeInitializeBody());
+
+    // The uncommitted transport is never tracked in the map and is closed to
+    // release its connected server deterministically.
+    expect(state.transports).toHaveLength(1);
+    expect(state.transports[0].close).toHaveBeenCalledTimes(1);
+    expect(state.transports[0].sessionId).toBeUndefined();
   });
 });

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -23,6 +23,12 @@ const SECURITY_HEADERS = {
 // Maximum number of concurrent HTTP sessions.
 const MAX_SESSIONS = 128;
 
+/**
+ * Signals that the request body was present but not valid JSON, so the caller
+ * can map it to a JSON-RPC parse error (-32700) instead of a generic 500.
+ */
+class RequestBodyParseError extends Error {}
+
 
 /**
  * Validate if an origin is from localhost
@@ -104,7 +110,7 @@ export class HttpTransportHandler {
         try {
           resolve(body ? JSON.parse(body) : {});
         } catch (error) {
-          reject(new Error('Invalid JSON in request body'));
+          reject(new RequestBodyParseError('Invalid JSON in request body'));
         }
       });
       req.on('error', reject);
@@ -435,16 +441,35 @@ export class HttpTransportHandler {
         const sessionId = req.headers['mcp-session-id'] as string | undefined;
 
         if (req.method === 'POST') {
-          const body = await this.parseRequestBody(req);
+          let body: unknown;
+          try {
+            body = await this.parseRequestBody(req);
+          } catch (error) {
+            if (error instanceof RequestBodyParseError) {
+              this.writeJsonRpcError(res, 400, -32700, 'Parse error: Invalid JSON in request body');
+              return;
+            }
+            throw error;
+          }
           const existing = sessionId ? transports.get(sessionId) : undefined;
 
-          if (existing) {
+          if (existing && sessionId) {
+            // Refresh recency: move this session to the tail of the insertion
+            // order so eviction targets the least-recently-used session (LRU).
+            transports.delete(sessionId);
+            transports.set(sessionId, existing);
             await existing.handleRequest(req, res, body);
             return;
           }
 
-          // Only a session-less initialize request may open a new session.
-          if (sessionId || !isInitializeRequest(body)) {
+          // A session id that is present but maps to no live transport is unknown.
+          if (sessionId) {
+            this.writeJsonRpcError(res, 404, -32001, 'Not Found: Unknown or expired session ID');
+            return;
+          }
+
+          // A session-less request may open a new session only via initialize.
+          if (!isInitializeRequest(body)) {
             this.writeJsonRpcError(res, 400, -32000, 'Bad Request: No valid session ID provided');
             return;
           }
@@ -484,11 +509,18 @@ export class HttpTransportHandler {
         }
 
         if (req.method === 'GET' || req.method === 'DELETE') {
-          const transport = sessionId ? transports.get(sessionId) : undefined;
-          if (!transport) {
-            this.writeJsonRpcError(res, 400, -32000, 'Bad Request: Missing or unknown session ID');
+          if (!sessionId) {
+            this.writeJsonRpcError(res, 400, -32000, 'Bad Request: Missing session ID');
             return;
           }
+          const transport = transports.get(sessionId);
+          if (!transport) {
+            this.writeJsonRpcError(res, 404, -32001, 'Not Found: Unknown or expired session ID');
+            return;
+          }
+          // Refresh recency so an active streaming session is not evicted (LRU).
+          transports.delete(sessionId);
+          transports.set(sessionId, transport);
           await transport.handleRequest(req, res);
           return;
         }

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -436,41 +436,50 @@ export class HttpTransportHandler {
 
         if (req.method === 'POST') {
           const body = await this.parseRequestBody(req);
-          let transport = sessionId ? transports.get(sessionId) : undefined;
+          const existing = sessionId ? transports.get(sessionId) : undefined;
 
-          if (!transport) {
-            // Only a session-less initialize request may open a new session.
-            if (sessionId || !isInitializeRequest(body)) {
-              this.writeJsonRpcError(res, 400, -32000, 'Bad Request: No valid session ID provided');
-              return;
-            }
-
-            // Bound the session map: evict the oldest session when at capacity
-            // so clients that abandon a session without DELETE cannot leak forever.
-            if (transports.size >= MAX_SESSIONS) {
-              const oldest = transports.keys().next().value;
-              if (oldest !== undefined) {
-                await transports.get(oldest)?.close();
-              }
-            }
-
-            const newTransport = new StreamableHTTPServerTransport({
-              sessionIdGenerator: () => randomUUID(),
-              onsessioninitialized: (id) => {
-                transports.set(id, newTransport);
-              },
-            });
-            newTransport.onclose = () => {
-              if (newTransport.sessionId) {
-                transports.delete(newTransport.sessionId);
-              }
-            };
-
-            await this.serverFactory().connect(newTransport);
-            transport = newTransport;
+          if (existing) {
+            await existing.handleRequest(req, res, body);
+            return;
           }
 
+          // Only a session-less initialize request may open a new session.
+          if (sessionId || !isInitializeRequest(body)) {
+            this.writeJsonRpcError(res, 400, -32000, 'Bad Request: No valid session ID provided');
+            return;
+          }
+
+          // Bound the session map: evict the oldest session when at capacity
+          // so clients that abandon a session without DELETE cannot leak forever.
+          if (transports.size >= MAX_SESSIONS) {
+            const oldest = transports.keys().next().value;
+            if (oldest !== undefined) {
+              await transports.get(oldest)?.close();
+            }
+          }
+
+          const transport = new StreamableHTTPServerTransport({
+            sessionIdGenerator: () => randomUUID(),
+            onsessioninitialized: (id) => {
+              transports.set(id, transport);
+            },
+          });
+          transport.onclose = () => {
+            if (transport.sessionId) {
+              transports.delete(transport.sessionId);
+            }
+          };
+
+          await this.serverFactory().connect(transport);
           await transport.handleRequest(req, res, body);
+
+          // If the handshake never assigned a session id, the transport was
+          // never tracked in the map (onsessioninitialized never fired), so
+          // close it to release the connected McpServer deterministically
+          // rather than leaving it for GC.
+          if (!transport.sessionId) {
+            await transport.close();
+          }
           return;
         }
 

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -1,6 +1,8 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import http from "http";
+import { randomUUID } from "node:crypto";
+import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
 import { TokenManager } from "../auth/tokenManager.js";
 import { CalendarRegistry } from "../services/CalendarRegistry.js";
 import { renderAuthSuccess, renderAuthError, loadWebFile } from "../web/templates.js";
@@ -17,6 +19,9 @@ const SECURITY_HEADERS = {
   'Referrer-Policy': 'strict-origin-when-cross-origin',
   'X-XSS-Protection': '1; mode=block'
 };
+
+// Maximum number of concurrent HTTP sessions.
+const MAX_SESSIONS = 128;
 
 
 /**
@@ -42,16 +47,16 @@ export interface HttpTransportConfig {
 }
 
 export class HttpTransportHandler {
-  private server: McpServer;
+  private serverFactory: () => McpServer;
   private config: HttpTransportConfig;
   private tokenManager: TokenManager;
 
   constructor(
-    server: McpServer,
+    serverFactory: () => McpServer,
     config: HttpTransportConfig = {},
     tokenManager: TokenManager
   ) {
-    this.server = server;
+    this.serverFactory = serverFactory;
     this.config = config;
     this.tokenManager = tokenManager;
   }
@@ -110,12 +115,8 @@ export class HttpTransportHandler {
     const port = this.config.port || 3000;
     const host = this.config.host || '127.0.0.1';
 
-    // Configure transport for stateless mode to allow multiple initialization cycles
-    const transport = new StreamableHTTPServerTransport({
-      sessionIdGenerator: undefined // Stateless mode - allows multiple initializations
-    });
-
-    await this.server.connect(transport);
+    // Per-session StreamableHTTP transports, keyed by mcp-session-id.
+    const transports = new Map<string, StreamableHTTPServerTransport>();
 
     // Create HTTP server to handle the StreamableHTTP transport
     const httpServer = http.createServer(async (req, res) => {
@@ -420,8 +421,86 @@ export class HttpTransportHandler {
         return;
       }
 
+      // MCP request handling: per-session StreamableHTTP transports (SDK stateful pattern)
       try {
-        await transport.handleRequest(req, res);
+        const sessionId = req.headers['mcp-session-id'] as string | undefined;
+
+        if (req.method === 'POST') {
+          const body = await this.parseRequestBody(req);
+          let transport = sessionId ? transports.get(sessionId) : undefined;
+
+          if (!transport) {
+            // Only a session-less initialize request may open a new session.
+            if (sessionId || !isInitializeRequest(body)) {
+              res.writeHead(400, { 'Content-Type': 'application/json' });
+              res.end(JSON.stringify({
+                jsonrpc: '2.0',
+                error: {
+                  code: -32000,
+                  message: 'Bad Request: No valid session ID provided',
+                },
+                id: null,
+              }));
+              return;
+            }
+
+            // Bound the session map: evict the oldest session when at capacity
+            // so clients that abandon a session without DELETE cannot leak forever.
+            if (transports.size >= MAX_SESSIONS) {
+              const oldest = transports.keys().next().value;
+              if (oldest !== undefined) {
+                await transports.get(oldest)?.close();
+              }
+            }
+
+            const newTransport = new StreamableHTTPServerTransport({
+              sessionIdGenerator: () => randomUUID(),
+              onsessioninitialized: (id) => {
+                transports.set(id, newTransport);
+              },
+            });
+            newTransport.onclose = () => {
+              if (newTransport.sessionId) {
+                transports.delete(newTransport.sessionId);
+              }
+            };
+
+            await this.serverFactory().connect(newTransport);
+            transport = newTransport;
+          }
+
+          await transport.handleRequest(req, res, body);
+          return;
+        }
+
+        if (req.method === 'GET' || req.method === 'DELETE') {
+          const transport = sessionId ? transports.get(sessionId) : undefined;
+          if (!transport) {
+            res.writeHead(400, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({
+              jsonrpc: '2.0',
+              error: {
+                code: -32000,
+                message: 'Bad Request: Missing or unknown session ID',
+              },
+              id: null,
+            }));
+            return;
+          }
+          await transport.handleRequest(req, res);
+          return;
+        }
+
+        // Any other method against the MCP endpoint is unsupported.
+        res.writeHead(405, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          jsonrpc: '2.0',
+          error: {
+            code: -32000,
+            message: 'Method Not Allowed',
+          },
+          id: null,
+        }));
       } catch (error) {
         process.stderr.write(`Error handling request: ${error instanceof Error ? error.message : error}\n`);
         if (!res.headersSent) {

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -111,6 +111,15 @@ export class HttpTransportHandler {
     });
   }
 
+  private writeJsonRpcError(res: http.ServerResponse, status: number, code: number, message: string): void {
+    res.writeHead(status, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({
+      jsonrpc: '2.0',
+      error: { code, message },
+      id: null,
+    }));
+  }
+
   async connect(): Promise<void> {
     const port = this.config.port || 3000;
     const host = this.config.host || '127.0.0.1';
@@ -432,15 +441,7 @@ export class HttpTransportHandler {
           if (!transport) {
             // Only a session-less initialize request may open a new session.
             if (sessionId || !isInitializeRequest(body)) {
-              res.writeHead(400, { 'Content-Type': 'application/json' });
-              res.end(JSON.stringify({
-                jsonrpc: '2.0',
-                error: {
-                  code: -32000,
-                  message: 'Bad Request: No valid session ID provided',
-                },
-                id: null,
-              }));
+              this.writeJsonRpcError(res, 400, -32000, 'Bad Request: No valid session ID provided');
               return;
             }
 
@@ -476,15 +477,7 @@ export class HttpTransportHandler {
         if (req.method === 'GET' || req.method === 'DELETE') {
           const transport = sessionId ? transports.get(sessionId) : undefined;
           if (!transport) {
-            res.writeHead(400, { 'Content-Type': 'application/json' });
-            res.end(JSON.stringify({
-              jsonrpc: '2.0',
-              error: {
-                code: -32000,
-                message: 'Bad Request: Missing or unknown session ID',
-              },
-              id: null,
-            }));
+            this.writeJsonRpcError(res, 400, -32000, 'Bad Request: Missing or unknown session ID');
             return;
           }
           await transport.handleRequest(req, res);
@@ -492,27 +485,11 @@ export class HttpTransportHandler {
         }
 
         // Any other method against the MCP endpoint is unsupported.
-        res.writeHead(405, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({
-          jsonrpc: '2.0',
-          error: {
-            code: -32000,
-            message: 'Method Not Allowed',
-          },
-          id: null,
-        }));
+        this.writeJsonRpcError(res, 405, -32000, 'Method Not Allowed');
       } catch (error) {
         process.stderr.write(`Error handling request: ${error instanceof Error ? error.message : error}\n`);
         if (!res.headersSent) {
-          res.writeHead(500, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({
-            jsonrpc: '2.0',
-            error: {
-              code: -32603,
-              message: 'Internal server error',
-            },
-            id: null,
-          }));
+          this.writeJsonRpcError(res, 500, -32603, 'Internal server error');
         }
       }
     });


### PR DESCRIPTION
## Summary

HTTP transport (`--transport http`) returns HTTP 500 on every MCP request after
the first `initialize`, so a real client's handshake
(`initialize` → `notifications/initialized` → `tools/list`) fails and no tools
mount. This adopts the SDK's standard **stateful per-session** transport pattern
to fix it. stdio transport behavior is unchanged.

## Root cause

`HttpTransportHandler` created a single `StreamableHTTPServerTransport` in
stateless mode (`sessionIdGenerator: undefined`) once in `connect()` and reused
it for every request. As of `@modelcontextprotocol/sdk >= 1.26`, a stateless
transport is **single-use**: the second `handleRequest` throws
("Stateless transport cannot be reused across requests"). The throw is swallowed
by the underlying `@hono/node-server` listener, which returns an empty 500 — so
it never reached the handler's own try/catch, which is why there was no error log.

## Changes

- **`src/transports/http.ts`** — replace the shared transport with a
  `Map<sessionId, StreamableHTTPServerTransport>`:
  - create a transport + `McpServer` on `initialize`, keyed by the generated
    `mcp-session-id`;
  - reuse the mapped transport for follow-up requests carrying that id;
  - return `404 / -32001` for a session id that is present but maps to no live
    transport (this tells a conforming MCP client to start a new session), and
    reserve `400 / -32000` for a genuinely missing session id — on both the POST
    and the GET/DELETE paths;
  - translate a malformed JSON request body to `400 / -32700` instead of the
    generic outer 500;
  - refresh session recency on every hit (delete + re-set the Map entry) so
    eviction is **LRU**, not FIFO — an active session is never evicted by newer
    idle ones;
  - tear the session down on `onclose` / HTTP `DELETE`, with a bounded
    `MAX_SESSIONS` cap so the session map can't grow without limit;
  - close an `initialize` transport whose handshake never commits a session id.
- **`src/server.ts`** — add a per-session `buildServer()` factory (since
  `server.connect()` binds one `McpServer` to one transport) and pass it to the
  HTTP handler; registration helpers now take the target server. The initial
  `McpServer` is now built **lazily** in `initialize()` rather than in the
  constructor, since HTTP mode only ever connects factory-created per-session
  servers. stdio still uses a single server.
- **`package.json`** — add a `test:integration:http` script mirroring the
  sibling `test:integration:*` scripts, so the HTTP integration test is
  runnable the standard way (`test:integration:all` already covers it too).

## Reviewer note

Origin validation, localhost CORS, `Accept` validation, and the account / OAuth /
health routes are unchanged — only the MCP fall-through handler changed.

## Testing

- Unit: `handlers.test.ts` covers the session lifecycle (create, reuse,
  unknown-id `404 / -32001`, missing-id `400 / -32000`, malformed-JSON
  `400 / -32700`, close/eviction cleanup, LRU eviction sparing a recently-touched
  session, `500`-on-throw, orphan-close); `GoogleCalendarMcpServer.test.ts`
  covers the factory / lazy initialize.
- Integration (`http-transport.test.ts`, now via `npm run test:integration:http`):
  spawns the built server in HTTP mode and drives **two sequential clients**
  through the full handshake, asserting `tools/list` returns the calendar tools
  and that a follow-up request on an established session no longer 500s (the
  original regression).
- Full suite green: `npm run lint`, `npm run test` (828 tests), `npm run build`,
  and `npm run test:integration:http`.

## Review follow-up

The prior "known residuals" (FIFO eviction and the unknown-session status) are
now addressed rather than accepted: eviction is LRU, and an unknown session id
returns `404 / -32001`. The lazy-server nit and the HTTP integration-test script
are also done. See the per-thread replies.

The `tool-description-analysis` CI check fails only at its final
"Post or update PR comment" step (`peter-evans/create-or-update-comment`) because
a fork PR's `GITHUB_TOKEN` cannot post comments; every analysis step itself
passes. `test-and-coverage` is green.

## Post-deploy monitoring & validation

No production/runtime monitoring required — HTTP mode is documented as
localhost development/testing only. Validate locally by starting
`node build/index.js --transport http` and confirming a client completes
`initialize` → `tools/list` and that a second request succeeds.
