### PR TITLE
fix(http): harden session transport handling

### DIFF
--- a/src/tests/unit/transports/handlers.test.ts
+++ b/src/tests/unit/transports/handlers.test.ts
@@ -88,7 +88,8 @@ import { HttpTransportHandler } from '../../../transports/http.js';
 import { StdioTransportHandler } from '../../../transports/stdio.js';
 
 function createMockResponse() {
-  return {
+  const res = new EventEmitter() as any;
+  Object.assign(res, {
     headers: {} as Record<string, string>,
     statusCode: 0,
     body: '',
@@ -108,7 +109,8 @@ function createMockResponse() {
         this.body += chunk;
       }
     }),
-  };
+  });
+  return res;
 }
 
 function createMockRequest(input: {
@@ -224,6 +226,27 @@ describe('Transport Handlers', () => {
     expect(res.statusCode).toBe(200);
     expect(res.headers['Access-Control-Allow-Origin']).toBe('http://127.0.0.1:4001');
     expect(JSON.parse(res.body).status).toBe('healthy');
+  });
+
+  it('allows MCP protocol and SSE resumption headers in CORS preflights', async () => {
+    const server = { connect: vi.fn(async () => undefined) } as any;
+    const handler = new HttpTransportHandler(() => server, { port: 4001, host: '127.0.0.1' }, makeTokenManager());
+    await handler.connect();
+
+    const req = createMockRequest({
+      method: 'OPTIONS',
+      url: '/',
+      headers: { origin: 'http://localhost:5173' }
+    });
+    const res = createMockResponse();
+
+    await invokeHandler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['Access-Control-Allow-Headers']).toBe(
+      'Content-Type, Mcp-Session-Id, Mcp-Protocol-Version, Last-Event-ID'
+    );
+    expect(res.headers['Access-Control-Expose-Headers']).toBe('Mcp-Session-Id');
   });
 
   it('returns account list via API endpoint', async () => {
@@ -374,6 +397,21 @@ describe('Transport Handlers', () => {
     expect(JSON.parse(res.body).error.code).toBe(-32700);
   });
 
+  it('returns 400/-32700 for an empty MCP POST body', async () => {
+    const server = { connect: vi.fn(async () => undefined) } as any;
+    const handler = new HttpTransportHandler(() => server, {}, makeTokenManager());
+    await handler.connect();
+
+    const req = createMockRequest({ method: 'POST', url: '/', headers: { accept: 'application/json' } });
+    const res = createMockResponse();
+    const pending = invokeHandler(req, res);
+    req.emit('end');
+    await pending;
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error.code).toBe(-32700);
+  });
+
   it('removes a session from the map when the transport closes', async () => {
     const server = { connect: vi.fn(async () => undefined) } as any;
     const handler = new HttpTransportHandler(() => server, {}, makeTokenManager());
@@ -415,6 +453,88 @@ describe('Transport Handlers', () => {
     // The touched oldest session survives; the now-LRU (second-created) is evicted.
     expect(oldest.transport.close).not.toHaveBeenCalled();
     expect(sessions[1].transport.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not evict a session with an active SSE response', async () => {
+    const server = { connect: vi.fn(async () => undefined) } as any;
+    const handler = new HttpTransportHandler(() => server, {}, makeTokenManager());
+    await handler.connect();
+
+    const MAX_SESSIONS = 128;
+    const sessions: Array<Awaited<ReturnType<typeof openSession>>> = [];
+    for (let i = 0; i < MAX_SESSIONS; i++) {
+      sessions.push(await openSession());
+    }
+
+    const active = sessions[0];
+    const streamReq = createMockRequest({
+      method: 'GET',
+      url: '/mcp',
+      headers: { accept: 'text/event-stream', 'mcp-session-id': active.sessionId }
+    });
+    const streamRes = createMockResponse();
+    await invokeHandler(streamReq, streamRes);
+
+    // Move every inactive session behind the active one, making the active
+    // session the least-recently-used entry in the map.
+    for (const session of sessions.slice(1)) {
+      const touchReq = createMockRequest({
+        method: 'POST',
+        url: '/',
+        headers: { accept: 'application/json', 'mcp-session-id': session.sessionId }
+      });
+      await postJson(
+        touchReq,
+        createMockResponse(),
+        { jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} }
+      );
+    }
+
+    await openSession();
+
+    expect(active.transport.close).not.toHaveBeenCalled();
+    expect(sessions[1].transport.close).toHaveBeenCalledTimes(1);
+
+    // Once the SSE response closes, the session is eligible for LRU eviction.
+    streamRes.emit('close');
+    await openSession();
+    expect(active.transport.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a new session when every session has an active SSE response', async () => {
+    const server = { connect: vi.fn(async () => undefined) } as any;
+    const handler = new HttpTransportHandler(() => server, {}, makeTokenManager());
+    await handler.connect();
+
+    const MAX_SESSIONS = 128;
+    const sessions: Array<Awaited<ReturnType<typeof openSession>>> = [];
+    const streamResponses: any[] = [];
+    for (let i = 0; i < MAX_SESSIONS; i++) {
+      const session = await openSession();
+      sessions.push(session);
+
+      const streamReq = createMockRequest({
+        method: 'GET',
+        url: '/mcp',
+        headers: { accept: 'text/event-stream', 'mcp-session-id': session.sessionId }
+      });
+      const streamRes = createMockResponse();
+      streamResponses.push(streamRes);
+      await invokeHandler(streamReq, streamRes);
+    }
+
+    const req = createMockRequest({ method: 'POST', url: '/', headers: { accept: 'application/json' } });
+    const res = createMockResponse();
+    await postJson(req, res, makeInitializeBody());
+
+    expect(res.statusCode).toBe(503);
+    expect(JSON.parse(res.body).error.code).toBe(-32000);
+    expect(state.transports).toHaveLength(MAX_SESSIONS);
+    expect(sessions.every(({ transport }) => transport.close.mock.calls.length === 0)).toBe(true);
+
+    for (const streamRes of streamResponses) {
+      streamRes.emit('close');
+    }
   });
 
   it('returns 500 when a mapped transport request handling throws', async () => {

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -24,8 +24,8 @@ const SECURITY_HEADERS = {
 const MAX_SESSIONS = 128;
 
 /**
- * Signals that the request body was present but not valid JSON, so the caller
- * can map it to a JSON-RPC parse error (-32700) instead of a generic 500.
+ * Signals that the request body was empty or not valid JSON, so the caller can
+ * map it to a JSON-RPC parse error (-32700) instead of a generic 500.
  */
 class RequestBodyParseError extends Error {}
 
@@ -102,13 +102,22 @@ export class HttpTransportHandler {
     validateAccountId(accountId);
   }
 
-  private parseRequestBody(req: http.IncomingMessage): Promise<any> {
+  private parseRequestBody(req: http.IncomingMessage, allowEmpty = true): Promise<any> {
     return new Promise((resolve, reject) => {
       let body = '';
       req.on('data', chunk => body += chunk.toString());
       req.on('end', () => {
+        if (!body) {
+          if (allowEmpty) {
+            resolve({});
+          } else {
+            reject(new RequestBodyParseError('Invalid JSON in request body'));
+          }
+          return;
+        }
+
         try {
-          resolve(body ? JSON.parse(body) : {});
+          resolve(JSON.parse(body));
         } catch (error) {
           reject(new RequestBodyParseError('Invalid JSON in request body'));
         }
@@ -132,6 +141,7 @@ export class HttpTransportHandler {
 
     // Per-session StreamableHTTP transports, keyed by mcp-session-id.
     const transports = new Map<string, StreamableHTTPServerTransport>();
+    const activeSseSessions = new Set<string>();
 
     // Create HTTP server to handle the StreamableHTTP transport
     const httpServer = http.createServer(async (req, res) => {
@@ -168,7 +178,11 @@ export class HttpTransportHandler {
         : `http://${host}:${port}`;
       res.setHeader('Access-Control-Allow-Origin', allowedCorsOrigin);
       res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
-      res.setHeader('Access-Control-Allow-Headers', 'Content-Type, mcp-session-id');
+      res.setHeader(
+        'Access-Control-Allow-Headers',
+        'Content-Type, Mcp-Session-Id, Mcp-Protocol-Version, Last-Event-ID'
+      );
+      res.setHeader('Access-Control-Expose-Headers', 'Mcp-Session-Id');
       
       if (req.method === 'OPTIONS') {
         res.writeHead(200);
@@ -443,7 +457,7 @@ export class HttpTransportHandler {
         if (req.method === 'POST') {
           let body: unknown;
           try {
-            body = await this.parseRequestBody(req);
+            body = await this.parseRequestBody(req, false);
           } catch (error) {
             if (error instanceof RequestBodyParseError) {
               this.writeJsonRpcError(res, 400, -32700, 'Parse error: Invalid JSON in request body');
@@ -474,12 +488,26 @@ export class HttpTransportHandler {
             return;
           }
 
-          // Bound the session map: evict the oldest session when at capacity
-          // so clients that abandon a session without DELETE cannot leak forever.
+          // Bound the session map by evicting the least-recently-used inactive
+          // session. Closing a transport with a live SSE response would
+          // disconnect a client that is still actively using its session.
           if (transports.size >= MAX_SESSIONS) {
-            const oldest = transports.keys().next().value;
-            if (oldest !== undefined) {
-              await transports.get(oldest)?.close();
+            let evicted = false;
+            for (const [candidateId, candidate] of transports) {
+              if (activeSseSessions.has(candidateId)) {
+                continue;
+              }
+
+              await candidate.close();
+              transports.delete(candidateId);
+              activeSseSessions.delete(candidateId);
+              evicted = true;
+              break;
+            }
+
+            if (!evicted) {
+              this.writeJsonRpcError(res, 503, -32000, 'Service Unavailable: Session capacity reached');
+              return;
             }
           }
 
@@ -492,6 +520,7 @@ export class HttpTransportHandler {
           transport.onclose = () => {
             if (transport.sessionId) {
               transports.delete(transport.sessionId);
+              activeSseSessions.delete(transport.sessionId);
             }
           };
 
@@ -518,9 +547,34 @@ export class HttpTransportHandler {
             this.writeJsonRpcError(res, 404, -32001, 'Not Found: Unknown or expired session ID');
             return;
           }
-          // Refresh recency so an active streaming session is not evicted (LRU).
+          // Refresh recency for both streaming and terminating session requests.
           transports.delete(sessionId);
           transports.set(sessionId, transport);
+
+          if (req.method === 'GET') {
+            activeSseSessions.add(sessionId);
+            let released = false;
+            const markStreamInactive = () => {
+              if (released) {
+                return;
+              }
+              released = true;
+              res.off('close', markStreamInactive);
+              res.off('finish', markStreamInactive);
+              activeSseSessions.delete(sessionId);
+            };
+            res.once('close', markStreamInactive);
+            res.once('finish', markStreamInactive);
+
+            try {
+              await transport.handleRequest(req, res);
+            } catch (error) {
+              markStreamInactive();
+              throw error;
+            }
+            return;
+          }
+
           await transport.handleRequest(req, res);
           return;
         }
@@ -539,4 +593,4 @@ export class HttpTransportHandler {
       process.stderr.write(`Google Calendar MCP Server listening on http://${host}:${port}\n`);
     });
   }
-} 
+}


### PR DESCRIPTION
Closes #194

This follow-up hardens the HTTP transport in three places:

- return the SDK-compatible JSON-RPC parse error for empty MCP POST bodies
- allow browser clients to send MCP protocol/session and SSE resumption headers, and expose the response session header
- preserve sessions with live SSE responses during LRU eviction; reject initialization with 503 when every slot is actively streaming

Tests cover empty-body handling, CORS headers, inactive-session eviction, active-session protection, and release after an SSE response closes.

Verification:
- npm run lint
- npm run check:imports
- npm test
- npm run test:coverage
- npm run test:integration:http