### PR TITLE
docs: tag README Cocal links with campaign attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ A Model Context Protocol (MCP) server that provides Google Calendar integration 
 <table>
 <tr>
 <td>
-<h3><a href="https://cocal.io"><img src="docs/images/cocal/logo.svg" alt="Cocal" width="144"></a></h3>
-<p>I built <a href="https://cocal.io">Cocal</a> as a separate hosted calendar assistant, taking this project further with a <strong>full visual calendar inside your chat with Claude.</strong> Connect your Google accounts without creating a Google Cloud project or running a server.</p>
+<h3><a href="https://cocal.io/?utm_source=google_calendar_mcp&amp;utm_medium=listing&amp;utm_campaign=release"><img src="docs/images/cocal/logo.svg" alt="Cocal" width="144"></a></h3>
+<p>I built <a href="https://cocal.io/?utm_source=google_calendar_mcp&amp;utm_medium=listing&amp;utm_campaign=release">Cocal</a> as a separate hosted calendar assistant, taking this project further with a <strong>full visual calendar inside your chat with Claude.</strong> Connect your Google accounts without creating a Google Cloud project or running a server.</p>
 <ul>
 <li><strong>Plan across accounts.</strong> Check availability and catch conflicts across your work, personal, and shared Google Calendars in one conversation.</li>
 <li><strong>Use it on desktop and mobile.</strong> See and manage your calendars in Claude on web, desktop, iOS, and Android.</li>
@@ -17,7 +17,7 @@ A Model Context Protocol (MCP) server that provides Google Calendar integration 
 <a href="docs/images/cocal/event-details.png"><img src="docs/images/cocal/event-details.png" alt="Cocal event card showing attendees, timezone context, a description, and no conflicts" width="300"></a>
 </p>
 <p><sub>Real Cocal UI with sample calendar data. Click either screenshot to enlarge.</sub></p>
-<p><strong><a href="https://cocal.io">Try Cocal →</a></strong></p>
+<p><strong><a href="https://cocal.io/?utm_source=google_calendar_mcp&amp;utm_medium=listing&amp;utm_campaign=release">Try Cocal →</a></strong></p>
 </td>
 </tr>
 </table>


### PR DESCRIPTION
Follow-up to #196. Tags all three `cocal.io` links in the README block (logo, inline mention, "Try Cocal →") with the canonical listing campaign:

```
https://cocal.io/?utm_source=google_calendar_mcp&utm_medium=listing&utm_campaign=release
```

**Why these exact values:** Cocal's analytics contract (`packages/core/src/analytics.ts`) is a fail-closed enum allowlist. `utm_source` accepts only `friends` or `google_calendar_mcp`; `utm_medium` only `referral` or `listing`; `utm_campaign` only `release`. Anything else is silently discarded, so invented values like `utm_source=github` would produce no attribution at all. This link is the one already specified in Cocal's `docs/release-analytics.md`.

**Why it's needed:** the collection contract deliberately drops referrer, so untagged README clicks are indistinguishable from direct traffic.

Verified against the real `campaignProperties()` implementation:

| link | result |
| --- | --- |
| tagged | `acquisition_source: google_calendar_mcp`, all three utm fields retained |
| untagged | `{}` |
| made-up values | `{}` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PBiRzdkuh985mJz4WCEL5i